### PR TITLE
removed stale slack link and updated typo on FAIR pages

### DIFF
--- a/app/views/about/us.html.erb
+++ b/app/views/about/us.html.erb
@@ -198,8 +198,7 @@
             </li>
             <li>
               <%= image_tag(asset_path("scilifelab/Slack-mark-black-RGB.png"), alt: 'icon', height: '40px', style: 'margin-right: 10px;') %>
-              <%= link_to "#training", "#", target: "_blank", rel: "noopener noreferrer" %>
-              Slack Channel (SciLifelab affiliation required)
+              Join the #training channel on the Scilifelab Slack
             </li>
           </ul>
 

--- a/app/views/our_resources/fair_training.html.erb
+++ b/app/views/our_resources/fair_training.html.erb
@@ -58,7 +58,7 @@
 
 <div class="row text-center">
   <br>
-  <p>Want to ensure your're on the right track? Connect with us at <%= mail_to(TeSS::Config.contact_email) %></p>
+  <p>Want to ensure you're on the right track? Connect with us at <%= mail_to(TeSS::Config.contact_email) %></p>
 </div>
 
 


### PR DESCRIPTION
**Summary of changes**

Issues: https://app.asana.com/0/1205707359650184/1206055942700373/f and https://app.asana.com/0/1205707359650184/1206055942392468/f 

- Remove stale slack link
- Fix typo on FAIR training page
