### PR TITLE
event tab not accessible on admin console#87

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,7 @@ en:
       event:
         county: Region
         presence:
+          one: 'Presence'
           online: Online
           onsite: Face-to-face
           hybrid: Hybrid


### PR DESCRIPTION
**Summary of changes**

-  Added missing key for event presence: rails admin to work

**Motivation and context**

[issue link](https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/87)
 
**Screenshots**

![image](https://github.com/SciLifeLab-TrainingHub-Platform/TeSS/assets/22519506/edf88248-997a-4db5-9942-18a9aa212c2d)


**Checklist**

- [ ] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [ ] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
