### PR TITLE
#72 | Redeveloping_Courses_Page

### DIFF
--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -9,7 +9,7 @@ module CollectionsHelper
   def item_fields(item_class)
     case item_class.name
     when "Event"
-      %i[title organizer event_types start country city eligibility created_at]
+      %i[title event_types start country city eligibility created_at]
     when "Material"
       %i[title target_audience status created_at]
     else

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -74,7 +74,7 @@ module EventsHelper
       events.each do |event|
         maker.items.new_item do |item|
           # required fields
-          item.title = [event.title, event.organizer.presence].compact.join(' - ')
+          item.title = [event.title].compact.join(' - ')
           item.link = event_url(event)
 
           # optional fields
@@ -98,7 +98,7 @@ module EventsHelper
   end
 
   def csv_column_names
-    return %w(Title Organizer Start End ContentProvider)
+    return %w(Title Start End ContentProvider)
   end
 
   def csv_from_collection(events)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,8 +32,6 @@ class Event < ApplicationRecord
       text :title
       text :keywords
       text :url
-      text :organizer
-      text :venue
       text :city
       text :country
       boolean :visible
@@ -54,9 +52,7 @@ class Event < ApplicationRecord
       end
       # other fields
       string :title
-      string :organizer
       string :sponsors, multiple: true
-      string :venue
       string :city
       string :country
       string :event_types, multiple: true do
@@ -106,6 +102,7 @@ class Event < ApplicationRecord
     # :nocov:
   end
 
+  attr_accessor :new_venues
   enum presence: { onsite: 0, online: 1, hybrid: 2 }
 
   belongs_to :user
@@ -116,6 +113,8 @@ class Event < ApplicationRecord
   has_many :event_materials, dependent: :destroy
   has_many :materials, through: :event_materials
   has_many :widget_logs, as: :resource
+  has_many :event_venues, dependent: :destroy
+  has_many :venues, through: :event_venues
 
   has_ontology_terms(:scientific_topics, branch: OBO_EDAM.topics)
   has_ontology_terms(:operations, branch: OBO_EDAM.operations)
@@ -150,6 +149,7 @@ class Event < ApplicationRecord
 
   NOMINATIM_DELAY = 1.minute
   NOMINATIM_MAX_ATTEMPTS = 3
+  VENUE_NAME_SEPARATOR = ';'.freeze
 
   def description=(desc)
     super(Rails::Html::FullSanitizer.new.sanitize(desc))
@@ -189,7 +189,7 @@ class Event < ApplicationRecord
 
   def self.facet_fields
     field_list = %w[ content_provider keywords scientific_topics operations tools fields online event_types
-                     start venue city country organizer sponsors target_audience eligibility user node collections ]
+                     start city country sponsors target_audience eligibility user node collections ]
 
     field_list.delete('operations') if TeSS::Config.feature['disabled'].include? 'operations'
     field_list.delete('scientific_topics') if TeSS::Config.feature['disabled'].include? 'topics'
@@ -203,15 +203,9 @@ class Event < ApplicationRecord
   end
 
   def to_csv_event
-    organizer = if self.organizer.instance_of?(String)
-                  self.organizer.tr(',', ' ')
-                elsif self.organizer.instance_of?(Array)
-                  self.organizer.join(' | ').gsub(',', ' and ')
-                end
     cp = content_provider.title unless content_provider.nil?
 
     [title.tr(',', ' '),
-     organizer,
      start.strftime('%d %b %Y'),
      self.end.strftime('%d %b %Y'),
      cp]
@@ -433,7 +427,7 @@ class Event < ApplicationRecord
     external_resources.each do |er|
       c.external_resources.build(url: er.url, title: er.title)
     end
-    %i[materials scientific_topics operations nodes].each do |field|
+    %i[materials scientific_topics operations nodes venues].each do |field|
       c.send("#{field}=", send(field))
     end
 
@@ -444,6 +438,23 @@ class Event < ApplicationRecord
     value = :online if value.is_a?(TrueClass) || value == '1' || value == 1 || value == 'true'
     value = :onsite if value.is_a?(FalseClass) || value == '0' || value == 0 || value == 'false'
     self.presence = value
+  end
+
+
+  def venue
+    venues.pluck(:name).join(', ')
+  end
+
+  def venue=(venue_string)
+    # If venue_string is not nil or empty, modify the venues association
+    if venue_string.present?
+      venue_names = venue_string.split(VENUE_NAME_SEPARATOR).map(&:strip).reject(&:empty?)
+      existing_venues = self.venues
+      new_venues = venue_names.map do |name|
+        Venue.find_or_create_by(name: name)
+      end
+      self.venues = (existing_venues + new_venues).uniq
+    end
   end
 
   private

--- a/app/models/event_venue.rb
+++ b/app/models/event_venue.rb
@@ -1,0 +1,4 @@
+class EventVenue < ApplicationRecord
+  belongs_to :event
+  belongs_to :venue
+end

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -1,0 +1,4 @@
+class Venue < ApplicationRecord
+  has_many :event_venues, dependent: :destroy
+  has_many :events, through: :event_venues
+end

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -5,7 +5,7 @@ class EventSerializer < ApplicationSerializer
 
              :start, :end, :duration, :timezone,
 
-             :organizer, :sponsors, :contact, :host_institutions,
+             :sponsors, :contact, :host_institutions,
 
              :online, :presence, :venue, :city, :county, :country, :postcode, :latitude, :longitude,
 

--- a/app/views/common/_extra_metadata.html.erb
+++ b/app/views/common/_extra_metadata.html.erb
@@ -32,7 +32,6 @@
   <%= display_attribute(resource, :learning_objectives, markdown: true) %>
   <%= display_attribute(resource, :eligibility) { |e| EligibilityDictionary.instance.lookup_value(e, 'title') } %>
 
-  <%= display_attribute(resource, :organizer) %>
   <%= display_attribute(resource, :host_institutions) { |values| values.join(', ') } %>
   <%= display_attribute(resource, :fields) { |values| values.join(', ') } %>
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -27,7 +27,7 @@
   <%= f.input :title, as: :string, field_lock: true, input_html: { title: t('events.hints.title') } %>
 
   <!-- Field: Sub-title -->
-  <%= f.input :subtitle, field_lock: true, input_html: { title: t('events.hints.subtitle') } %>
+  <%#= f.input :subtitle, field_lock: true, input_html: { title: t('events.hints.subtitle') } %>
 
   <!-- Field: URL -->
   <%= render partial: 'common/url_checker',
@@ -38,17 +38,17 @@
               field_lock: true %>
 
   <!-- Field: Start -->
-  <%= f.input :start, as: :datetime_picker, field_lock: true, input_html: { title: t('events.hints.start') } %>
+  <%= f.input :start, as: :date_picker, field_lock: true, input_html: { title: t('events.hints.start') } %>
 
   <!-- Field: End -->
-  <%= f.input :end, as: :datetime_picker, field_lock: true, input_html: { title: t('events.hints.end') } %>
+  <%= f.input :end, as: :date_picker, field_lock: true, input_html: { title: t('events.hints.end') } %>
 
   <!-- Field: Timezone -->
   <%= f.input :timezone, as: :time_zone, field_lock: true, priority: priority_time_zones,
               input_html: { class: 'js-select2', title: t('events.hints.timezone') } %>
 
   <!-- Field: Duration -->
-  <%= f.input :duration, as: :string, input_html: { title: t('events.hints.duration') } %>
+  <%#= f.input :duration, as: :string, input_html: { title: t('events.hints.duration') } %>
 
   <!-- Field: Prerequisites -->
   <%= f.input :prerequisites, as: :markdown_area, input_html: { rows: '3', title: t('events.hints.prerequisites') } %>
@@ -63,14 +63,11 @@
   </div>
 
   <!-- Field: Eligibility -->
-  <%= f.dropdown :eligibility,
+  <%#= f.dropdown :eligibility,
                  options: EligibilityDictionary.instance.options_for_select,
                  label: 'Eligibility',
                  errors: @event.errors[:eligibility],
                  title: t('events.hints.eligibility') %>
-
-  <!-- Field: Organiser -->
-  <%= f.input :organizer, field_lock: true, label: 'Organiser', input_html: { title: t('events.hints.organizer') } %>
 
   <!-- Field: Contact -->
   <%= f.input :contact, input_html: { rows: '5', title: t('events.hints.contact') }, field_lock: true %>
@@ -104,10 +101,10 @@
   <% end %>
 
   <!-- Operations: check disabled -->
-  <% if !TeSS::Config.feature['disabled'].include? 'operations' %>
-    <%= f.autocompleter :operations, url: edam_operations_path, template: 'autocompleter/term',
+  <%# if !TeSS::Config.feature['disabled'].include? 'operations' %>
+    <%#= f.autocompleter :operations, url: edam_operations_path, template: 'autocompleter/term',
                         id_field: :uri, label_field: :preferred_label %>
-  <% end %>
+  <%# end %>
 
   <!-- Field: Capacity -->
   <%= f.input :capacity, as: :integer, field_lock: true,
@@ -121,7 +118,7 @@
   <%= f.input :tech_requirements, as: :markdown_area, input_html: { rows: '3', title: t('events.hints.requirements') } %>
 
   <!-- Field: Credit or Recognition -->
-  <%= f.input :recognition, as: :string, field_lock: true, label: 'Credit or Recognition of Attendance',
+  <%#= f.input :recognition, as: :string, field_lock: true, label: 'Credit or Recognition of Attendance',
               input_html: { title: t('events.hints.recognition') } %>
 
   <!-- Field: External Resources -->
@@ -137,7 +134,7 @@
   </div>
 
   <!-- Field: Content Provider -->
-  <%= f.input :content_provider_id, label: 'Content provider (where the event metadata is obtained from)',
+  <%= f.input :content_provider_id, label: 'Content provider (Training Organizer)',
               collection: current_user.get_editable_providers, label_method: :title, value_method: :id, include_blank: true,
               field_lock: true %>
 
@@ -153,9 +150,9 @@
   <% end %>
 
   <!-- Sponsors: check disabled -->
-  <% if !TeSS::Config.feature['disabled'].include? 'sponsors' %>
-    <%= f.multi_input :sponsors, errors: @event.errors[:sponsors], hint: t('events.hints.sponsors') %>
-  <% end %>
+  <%# if !TeSS::Config.feature['disabled'].include? 'sponsors' %>
+    <%#= f.multi_input :sponsors, errors: @event.errors[:sponsors], hint: t('events.hints.sponsors') %>
+  <%# end %>
 
   <div class="form-group">
     <%= f.submit (f.object.new_record? ? "Add" : "Update") + " event", :class => 'btn btn-primary' %>

--- a/app/views/events/index.json.jbuilder
+++ b/app/views/events/index.json.jbuilder
@@ -1,4 +1,4 @@
-base_fields = [:id, :external_id, :title, :subtitle, :url, :organizer, :description, :start, :end, :sponsors, :venue,
+base_fields = [:id, :external_id, :title, :subtitle, :url, :description, :start, :end, :sponsors, :venue,
                :city, :country, :postcode, :latitude, :longitude, :created_at, :updated_at, :source, :slug,
                :content_provider_id, :user_id, :last_scraped, :scraper_record, :keywords, :event_types,
                :target_audience, :capacity, :eligibility, :contact, :host_institutions, :prerequisites,

--- a/app/views/events/partials/_address_finder.html.erb
+++ b/app/views/events/partials/_address_finder.html.erb
@@ -16,14 +16,30 @@
 </div>
 
 <div class="manual-address-fields">
-  <%= f.input :venue, field_lock: true %>
+  <div class="field">
+    <%= f.label :venue_ids, "Venues", class: 'control-label'%><%= f.field_lock(:venue_ids) %> <a class="btn-link" role="button" tabindex="0" data-toggle="collapse" data-target="#new_venue_collapse"><small>Add new venue</small></a>
+    <%= f.collection_select :venue_ids, @venues, :id, :name, { include_blank: false }, { class: 'js-select2', style: 'width: 100%;', multiple: true } do |venue| %>
+      <option value="<%= venue.id %>" <%= 'selected="selected"' if @selected_venue_ids.include?(venue.id) %>>
+        <%= venue.name %>
+      </option>
+    <% end %>
+    <span class="help-block">Choose one or more venues for the event. To add new venue click "Add new venue"</span>
+  </div>
+
+  <div id="new_venue_collapse" class="collapse">
+    <%= f.text_area :new_venues, placeholder: "Enter new venues separated by Semicolon (;)", rows: 5, style: "width: 100%;", field_lock: true %>
+    <br>
+  </div>
+
   <%= f.input :city, field_lock: true, required: true %>
+
   <!-- County: check disabled -->
-  <% if !TeSS::Config.feature['disabled'].include? 'county' %>
-    <%= f.input :county, field_lock: true %>
-  <% end %>
+  <%# if !TeSS::Config.feature['disabled'].include? 'county' %>
+    <%#= f.input :county, field_lock: true %>
+  <%# end %>
+
   <% alpha2 = @event.nil? ? '' : country_alpha2_by_name(@event.country) %>
-  <%= f.input :country, priority: priority_countries, field_lock: true, required: true, selected: alpha2 %>
+  <%= f.input :country, priority: priority_countries, field_lock: true, required: true, selected: "SE" %>
   <%= f.input :postcode, field_lock: true %>
   <%= f.hidden_field :latitude %>
   <%= f.hidden_field :longitude %>

--- a/app/views/events/show.json.jbuilder
+++ b/app/views/events/show.json.jbuilder
@@ -7,7 +7,7 @@ fields = [
 
   :start, :end, :duration, :timezone,
 
-  :organizer, :sponsors, :contact, :host_institutions,
+  :sponsors, :contact, :host_institutions,
 
   :venue, :city, :county, :country, :postcode, :latitude, :longitude,
 

--- a/config/dictionaries/cost_basis.yml
+++ b/config/dictionaries/cost_basis.yml
@@ -1,9 +1,6 @@
 free:
   title: Free to all
   description: This event is free for all participants
-hosts:
-  title: Cost to non-members
-  description: This event is only free for participants from host institutions and members of the provider organization.
 charge:
   title: Cost incurred by all
   description: This event has an associated charge for participants.

--- a/db/migrate/20240531095558_remove_organizer_from_event.rb
+++ b/db/migrate/20240531095558_remove_organizer_from_event.rb
@@ -1,0 +1,5 @@
+class RemoveOrganizerFromEvent < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :events, :organizer, :string
+  end
+end

--- a/db/migrate/20240531095754_create_venues.rb
+++ b/db/migrate/20240531095754_create_venues.rb
@@ -1,0 +1,9 @@
+class CreateVenues < ActiveRecord::Migration[7.0]
+  def change
+    create_table :venues do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240531095943_create_event_venues.rb
+++ b/db/migrate/20240531095943_create_event_venues.rb
@@ -1,0 +1,10 @@
+class CreateEventVenues < ActiveRecord::Migration[7.0]
+  def change
+    create_table :event_venues do |t|
+      t.references :event, null: false, foreign_key: true
+      t.references :venue, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240531100723_remove_venue_from_event.rb
+++ b/db/migrate/20240531100723_remove_venue_from_event.rb
@@ -1,0 +1,5 @@
+class RemoveVenueFromEvent < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :events, :venue, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_26_090005) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_31_100723) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -36,7 +36,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_26_090005) do
     t.bigint "user_id"
     t.string "name"
     t.jsonb "properties"
-    t.datetime "time"
+    t.datetime "time", precision: nil
     t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
     t.index ["properties"], name: "index_ahoy_events_on_properties", opclass: :jsonb_path_ops, using: :gin
     t.index ["user_id"], name: "index_ahoy_events_on_user_id"
@@ -68,7 +68,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_26_090005) do
     t.string "app_version"
     t.string "os_version"
     t.string "platform"
-    t.datetime "started_at"
+    t.datetime "started_at", precision: nil
     t.index ["user_id"], name: "index_ahoy_visits_on_user_id"
     t.index ["visit_token"], name: "index_ahoy_visits_on_visit_token", unique: true
   end
@@ -177,17 +177,24 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_26_090005) do
     t.index ["material_id"], name: "index_event_materials_on_material_id"
   end
 
+  create_table "event_venues", force: :cascade do |t|
+    t.bigint "event_id", null: false
+    t.bigint "venue_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_event_venues_on_event_id"
+    t.index ["venue_id"], name: "index_event_venues_on_venue_id"
+  end
+
   create_table "events", force: :cascade do |t|
     t.string "external_id"
     t.string "title"
     t.string "subtitle"
     t.string "url"
-    t.string "organizer"
     t.text "description"
     t.datetime "start"
     t.datetime "end"
     t.string "sponsors", default: [], array: true
-    t.text "venue"
     t.string "city"
     t.string "county"
     t.string "country"
@@ -319,14 +326,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_26_090005) do
     t.index ["user_id"], name: "index_learning_paths_on_user_id"
   end
 
-  create_table "link_monitors", force: :cascade do |t|
+  create_table "link_monitors", id: :serial, force: :cascade do |t|
     t.string "url"
     t.integer "code"
-    t.datetime "failed_at"
-    t.datetime "last_failed_at"
+    t.datetime "failed_at", precision: nil
+    t.datetime "last_failed_at", precision: nil
     t.integer "fail_count"
-    t.integer "lcheck_id"
     t.string "lcheck_type"
+    t.integer "lcheck_id"
     t.index ["lcheck_type", "lcheck_id"], name: "index_link_monitors_on_lcheck_type_and_lcheck_id"
   end
 
@@ -448,8 +455,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_26_090005) do
   create_table "sources", force: :cascade do |t|
     t.bigint "content_provider_id"
     t.bigint "user_id"
-    t.datetime "created_at"
-    t.datetime "finished_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "finished_at", precision: nil
     t.string "url"
     t.string "method"
     t.integer "records_read"
@@ -461,7 +468,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_26_090005) do
     t.boolean "enabled"
     t.string "token"
     t.integer "approval_status"
-    t.datetime "updated_at"
+    t.datetime "updated_at", precision: nil
     t.index ["content_provider_id"], name: "index_sources_on_content_provider_id"
     t.index ["user_id"], name: "index_sources_on_user_id"
   end
@@ -532,9 +539,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_26_090005) do
     t.string "uid"
     t.string "identity_url"
     t.string "invitation_token"
-    t.datetime "invitation_created_at"
-    t.datetime "invitation_sent_at"
-    t.datetime "invitation_accepted_at"
+    t.datetime "invitation_created_at", precision: nil
+    t.datetime "invitation_sent_at", precision: nil
+    t.datetime "invitation_accepted_at", precision: nil
     t.integer "invitation_limit"
     t.string "invited_by_type"
     t.bigint "invited_by_id"
@@ -543,19 +550,25 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_26_090005) do
     t.string "image_file_name"
     t.string "image_content_type"
     t.bigint "image_file_size"
-    t.datetime "image_updated_at"
+    t.datetime "image_updated_at", precision: nil
     t.index ["authentication_token"], name: "index_users_on_authentication_token"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["identity_url"], name: "index_users_on_identity_url", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
-    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by"
+    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["role_id"], name: "index_users_on_role_id"
     t.index ["slug"], name: "index_users_on_slug", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
+  end
+
+  create_table "venues", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "widget_logs", force: :cascade do |t|
@@ -601,6 +614,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_26_090005) do
   add_foreign_key "content_providers", "users"
   add_foreign_key "event_materials", "events"
   add_foreign_key "event_materials", "materials"
+  add_foreign_key "event_venues", "events"
+  add_foreign_key "event_venues", "venues"
   add_foreign_key "events", "users"
   add_foreign_key "learning_path_topic_links", "learning_paths"
   add_foreign_key "learning_paths", "content_providers"

--- a/lib/bioschemas/course_instance_generator.rb
+++ b/lib/bioschemas/course_instance_generator.rb
@@ -10,7 +10,7 @@ module Bioschemas
 
     property :startDate, :start
     property :endDate, :end
-    property :organizer, -> (event) { { '@type' => 'Organization', name: event.organizer } if event.organizer.present? }
+    # property :organizer, -> (event) { { '@type' => 'Organization', name: event.organizer } if event.organizer.present? }
     property :location, -> (event) { address(event) },
              condition: -> (event) { event.venue.present? || event.city.present? || event.county.present? ||
                event.country.present? || event.postcode.present? }

--- a/lib/bioschemas/event_generator.rb
+++ b/lib/bioschemas/event_generator.rb
@@ -15,7 +15,6 @@ module Bioschemas
     property :keywords, :keywords
     property :startDate, :start
     property :endDate, :end
-    property :organizer, -> (event) { { '@type' => 'Organization', name: event.organizer } if event.organizer.present? }
     property :location, -> (event) { address(event) },
              condition: -> (event) { event.venue.present? || event.city.present? || event.county.present? ||
                event.country.present? || event.postcode.present? }

--- a/lib/ingestors/event_csv_ingestor.rb
+++ b/lib/ingestors/event_csv_ingestor.rb
@@ -31,7 +31,6 @@ module Ingestors
           event.end = get_column row, 'End'
           event.timezone = get_column row, 'Timezone'
           event.contact = get_column row, 'Contact'
-          event.organizer = get_column row, 'Organizer'
           event.eligibility = process_array row, 'Eligibility'
           event.host_institutions = process_array row, 'Host Institutions'
           event.online = get_column row, 'Online'

--- a/lib/ingestors/eventbrite_ingestor.rb
+++ b/lib/ingestors/eventbrite_ingestor.rb
@@ -84,10 +84,6 @@ module Ingestors
                                  true
                                end
 
-                # organizer
-                organizer = get_eventbrite_organizer item['organizer_id']
-                event.organizer = organizer['name'] unless organizer.nil?
-
                 # address fields
                 venue = get_eventbrite_venue item['venue_id']
                 unless venue.nil? or venue['address'].nil?
@@ -281,19 +277,19 @@ module Ingestors
       subcategories
     end
 
-    def get_eventbrite_organizer(id)
-      # abort on bad input
-      return nil if id.nil? or id == 'null'
-
-      # initialize cache
-      @eventbrite_objects[:organizers] = {} if @eventbrite_objects[:organizers].nil?
-
-      # not in cache
-      populate_eventbrite_organizer id unless @eventbrite_objects[:organizers].keys.include? id
-
-      # return from cache
-      @eventbrite_objects[:organizers][id]
-    end
+    # def get_eventbrite_organizer(id)
+    #   # abort on bad input
+    #   return nil if id.nil? or id == 'null'
+    #
+    #   # initialize cache
+    #   @eventbrite_objects[:organizers] = {} if @eventbrite_objects[:organizers].nil?
+    #
+    #   # not in cache
+    #   populate_eventbrite_organizer id unless @eventbrite_objects[:organizers].keys.include? id
+    #
+    #   # return from cache
+    #   @eventbrite_objects[:organizers][id]
+    # end
 
     def populate_eventbrite_organizer(id)
       # get from query and add to cache if found

--- a/lib/ingestors/libcal_ingestor.rb
+++ b/lib/ingestors/libcal_ingestor.rb
@@ -39,7 +39,6 @@ module Ingestors
           attr = item
           event.title = attr.fetch('title', '')
           event.url = attr.fetch('url', '')&.strip
-          event.organizer = attr.fetch('org', '')
           event.description = convert_description attr.fetch('description', '')
           event.start = attr.fetch('startdt', '')
           event.end = attr.fetch('enddt', '')

--- a/lib/ingestors/tess_event_ingestor.rb
+++ b/lib/ingestors/tess_event_ingestor.rb
@@ -44,7 +44,6 @@ module Ingestors
           event.end = attr['end']
           event.timezone = 'UTC'
           event.contact = attr['contact']
-          event.organizer = attr['organizer']
           event.online = attr['online']
           event.city = attr['city']
           event.country = attr['country']

--- a/lib/ingestors/utwente_ingestor.rb
+++ b/lib/ingestors/utwente_ingestor.rb
@@ -49,7 +49,6 @@ module Ingestors
         event.keywords = item['tags'].map{ |t| t['tag'] }
         event.description = convert_description item['description']
         event.timezone = 'Amsterdam'
-        event.organizer = 'University of Twente'
         event.source = 'University of Twente'
         add_event(event)
       rescue Exception => e

--- a/lib/ingestors/uva_ingestor.rb
+++ b/lib/ingestors/uva_ingestor.rb
@@ -40,7 +40,6 @@ module Ingestors
         attr = item
         event.title = attr.fetch('title', '')
         event.url = attr.fetch('url', '')&.strip
-        event.organizer = attr.fetch('org', '')
         event.description = convert_description attr.fetch('lead', '')
         event.start = attr.fetch('startDate', '')
         event.end = attr.fetch('endDate', '')

--- a/test/controllers/content_providers_controller_test.rb
+++ b/test/controllers/content_providers_controller_test.rb
@@ -457,7 +457,11 @@ class ContentProvidersControllerTest < ActionController::TestCase
   test 'show consistent count on content provider page' do
     sign_in users(:admin)
 
-    @content_provider.events.delete_all
+    # Ensure events and their associated events_venues are deleted
+    @content_provider.events.each do |event|
+      event.destroy
+    end
+
     # make sure this content provider has events in the past, future and without date
     good_user = users(:admin)
     past_event = good_user.events.build(title: 'past',

--- a/test/controllers/curator_controller_test.rb
+++ b/test/controllers/curator_controller_test.rb
@@ -81,7 +81,7 @@ class CuratorControllerTest < ActionController::TestCase
     assert_not_includes assigns(:users), new_user
 
     e = new_user.events.create!(title: 'Spam event', url: 'http://cool-event.pancakes', start: 10.days.from_now,
-                                description: "test event", organizer: "test organizer", end: 11.days.from_now,
+                                description: "test event", end: 11.days.from_now,
                                 eligibility: [ 'registration_of_interest' ], host_institutions: [ "MIT" ],
                                 contact: "me", online: true, timezone: 'UTC'
                                 )
@@ -133,7 +133,7 @@ class CuratorControllerTest < ActionController::TestCase
     node = nil
     4.times do |i|
       e = new_user.events.create!(title: "Spam event #{i}", url: "http://cool-event.pancakes/#{i}", start: 10.days.from_now,
-                                  description: "test event", organizer: "test organizer", end: 11.days.from_now,
+                                  description: "test event", end: 11.days.from_now,
                                   eligibility: [ 'registration_of_interest' ], host_institutions: [ "MIT" ],
                                   contact: "me", online: true, timezone: 'UTC')
       e.create_activity(:create, owner: new_user)

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -18,7 +18,7 @@ class EventsControllerTest < ActionController::TestCase
     @failing_event = events(:failing_event)
     @failing_event.title = 'Fail!'
     @monitor = @failing_event.create_link_monitor(url: @failing_event.url, code: 404, fail_count: 5)
-    @mandatory_fields = { online: true, start: @event.start, end: @event.end, organizer: @event.organizer,
+    @mandatory_fields = { online: true, start: @event.start, end: @event.end,
                           host_institutions: @event.host_institutions, timezone: @event.timezone,
                           contact: @event.contact, eligibility: @event.eligibility }
   end
@@ -734,7 +734,7 @@ class EventsControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal 'text/csv; charset=utf-8', @response.content_type
     csv_events = CSV.parse(@response.body)
-    assert_equal csv_events.first, %w[Title Organizer Start End ContentProvider]
+    assert_equal csv_events.first, %w[Title Start End ContentProvider]
   end
 
   test 'should provide an RSS file' do

--- a/test/fixtures/event_venues.yml
+++ b/test/fixtures/event_venues.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  event: one
+  venue: one
+
+two:
+  event: two
+  venue: two

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -5,13 +5,11 @@ one:
   title: "event one"
   subtitle: MyString
   url: http://example.com/cool-event
-  organizer: MyString
   description: MyText
   event_types: ["workshops_and_courses"]
   start: 2015-11-23 10:16:33
   end: 2015-11-23 10:16:33
   sponsors: ["MyString"]
-  venue: MyText
   city: MyString
   county: MyString
   country: MyString
@@ -34,14 +32,12 @@ two:
   title: "event two"
   subtitle: MyString
   url: http://example.com/a-different-event
-  organizer: MyString
   description: MyText
   event_types: ["meetings_and_conferences"]
   duration: '23:59'
   start: 2015-11-23 00:00:00
   end: 2015-11-24 00:00:00
   sponsors: ["MyString"]
-  venue: MyText
   city: MyString
   county: MyString
   country: MyString
@@ -112,12 +108,10 @@ scraper_user_event:
   eligibility: [ registration_of_interest ]
   start: 2016-12-12 10:00:00
   end: 2016-12-12 12:00:00
-  venue: MyHall
   city: Somewhere Awesome
   country: BigCountry
   postcode: 1010
-  organizer: AnOrganizer
-
+  
 event_with_external_resource:
   title: External Resource Event
   url: http://myurl.com
@@ -130,12 +124,10 @@ event_with_external_resource:
   eligibility: [ registration_of_interest ]
   start: 2016-12-12 10:00:00
   end: 2016-12-12 12:00:00
-  venue: MyHall
   city: Somewhere Awesome
   country: BigCountry
   postcode: 1010
-  organizer: AnOrganizer
-
+  
 event_with_no_start:
   title: No Start Time
   url: http://myurl.com
@@ -147,12 +139,10 @@ event_with_no_start:
   contact: MyContact
   eligibility: [ registration_of_interest ]
   end: 2016-12-12 12:00:00
-  venue: MyHall
   city: Somewhere Awesome
   country: BigCountry
   postcode: 1010
-  organizer: AnOrganizer
-
+  
 event_with_no_end:
   title: No End Time
   url: http://myurl.com
@@ -164,12 +154,10 @@ event_with_no_end:
   timezone: UTC
   contact: MyContact
   eligibility: [ registration_of_interest ]
-  venue: MyHall
   city: Somewhere Awesome
   country: BigCountry
   postcode: 1010
-  organizer: AnOrganizer
-
+  
 online_event_with_no_end:
   title: No End Time
   url: http://myurl.com
@@ -182,12 +170,10 @@ online_event_with_no_end:
   timezone: UTC
   contact: MyContact
   eligibility: [ registration_of_interest ]
-  venue: MyHall
   city: Somewhere Awesome
   country: BigCountry
   postcode: 1010
-  organizer: AnOrganizer
-
+  
 organisation_event:
   title: Fun Training Day
   url: http://content-provider.org/event
@@ -200,12 +186,10 @@ organisation_event:
   timezone: UTC
   contact: MyContact
   eligibility: [ registration_of_interest ]
-  venue: MyHall
   city: Somewhere Awesome
   country: BigCountry
   postcode: 1010
-  organizer: AnOrganizer
-
+  
 portal_event:
   presence: 0
   title: Awesome Training Day
@@ -219,12 +203,10 @@ portal_event:
   timezone: UTC
   contact: MyContact
   eligibility: [ registration_of_interest ]
-  venue: "Birmingham City Hall"
   city: "Birmingham"
   country: "United Kingdom"
   postcode: "B1 1BB"
-  organizer: AnOrganizer
-
+  
 dodgy_country_event:
   title: Fun Training Day
   url: http://content-provider.org/event
@@ -238,11 +220,9 @@ dodgy_country_event:
   timezone: London
   contact: MyContact
   eligibility: [ registration_of_interest ]
-  venue: MyHall
   city: Somewhere Awesome
   postcode: 1010
-  organizer: AnOrganizer
-
+  
 no_description_event:
   title: All you need to know is in the title
   url: http://content-provider.org/no-desc-event
@@ -254,12 +234,10 @@ no_description_event:
   timezone: Australia/Melbourne
   contact: MyContact
   eligibility: [ registration_of_interest ]
-  venue: MyHall
   city: Melbourne
   country: Australia
   postcode: 3000
-  organizer: AnOrganizer
-
+  
 event_with_report:
   title: This event happened
   url: http://content-provider.org/event-with-report
@@ -274,12 +252,10 @@ event_with_report:
   timezone: Australia/Sydney
   contact: MyContact
   eligibility: [ registration_of_interest ]
-  venue: MyHall
   city: Sydney
   country: AU
   postcode: 1000
-  organizer: AnOrganizer
-
+  
 another_event_with_report:
   title: This event happened
   url: http://content-provider.org/another-event-with-report
@@ -292,24 +268,20 @@ another_event_with_report:
   timezone: UTC
   contact: MyContact
   eligibility: [ registration_of_interest ]
-  venue: MyHall
   city: Somewhere Awesome
   country: BigCountry
   postcode: 1010
-  organizer: AnOrganizer
-
+  
 shadowbanned_event:
   external_id: MyString1
   title: PredConf 2018
   subtitle: MyString
   url: http://example.com/predconf
-  organizer: MyString
   description: MyText
   event_types: ["workshops_and_courses"]
   start: 2018-11-23 10:16:33
   end: 2018-11-23 10:16:33
   sponsors: ["MyString"]
-  venue: MyText
   city: MyString
   county: MyString
   country: MyString
@@ -335,7 +307,6 @@ failing_event:
   timezone: GMT
   contact: MyContact
   eligibility: [ registration_of_interest ]
-  venue: Kilburn Building
   city: Manchester
   county: Greater Manchester
   country: United Kingdom
@@ -348,7 +319,6 @@ kilburn:
   event_types: ["meetings_and_conferences"]
   start: 2019-11-23 00:00:00
   end: 2019-11-24 00:00:00
-  venue: Kilburn Building
   city: Manchester
   county: Greater Manchester
   country: United Kingdom
@@ -358,20 +328,17 @@ kilburn:
   timezone: Europe/London
   contact: MyContact
   eligibility: [ registration_of_interest ]
-  organizer: "The Organizer"
 
 calendar_event:
   title: "calendar event"
   subtitle: "an event to test calendar exports"
   url: http://microsoft.com
-  organizer: MyString
   description: MyText
   event_types: ["meetings_and_conferences"]
   duration: '01:45'
   start: 2021-09-20 23:15:00
   end: 2021-09-21 01:00:00
   sponsors: ["MyString"]
-  venue: 100, Lygon Street
   city: Carlton
   country: Australia
   postcode: 3010
@@ -386,14 +353,12 @@ training_event:
   title: "calendar event"
   subtitle: "an event to test calendar exports"
   url: http://microsoft.com
-  organizer: EventsCo
   description: MyText
   event_types: ["meetings_and_conferences"]
   duration: '01:45'
   start: 2021-09-20 23:15:00
   end: 2021-09-21 01:00:00
   sponsors: ["FundingCorp"]
-  venue: 100, Lygon Street
   city: Carlton
   country: Australia
   postcode: 3010
@@ -411,14 +376,12 @@ ical_event_1:
   title: P'Con - Embracing new solutions for in-situ visualisation
   url: 'https://pawsey.org.au/event/pcon-embracing-new-solutions-for-in-situ-visualisation/'
   subtitle: "an event to test calendar ingestion"
-  organizer: MyString
   description: MyText
   event_types: ["meetings_and_conferences"]
   duration: '01:45'
   start: 2021-12-08 12:30:00 +0800
   end: 2021-12-08 13:30:00 +0800
   sponsors: ["MyString"]
-  venue: 100, Lygon Street
   city: Carlton
   country: Australia
   postcode: 3010
@@ -434,14 +397,12 @@ ical_event_2:
   title: "PaCER Seminar: Computational Fluid Dynamics"
   url: 'https://pawsey.org.au/event/pacer-seminar-computational-fluid-dynamics/'
   subtitle: "an event to test calendar ingestion"
-  organizer: MyString
   description: MyText
   event_types: ["meetings_and_conferences"]
   duration: '01:45'
   start: 2022-06-15 10:00:00 +0800
   end: 2022-06-15 12:00:00 +0800
   sponsors: ["MyString"]
-  venue: 100, Lygon Street
   city: Carlton
   country: Australia
   postcode: 3010
@@ -457,13 +418,11 @@ course_event:
   title: Summer Course on Learning Stuff
   subtitle: Expand your horizons
   url: http://example.com/cool-course-summer
-  organizer: CourseCo
   description: Learn lots of stuff!
   event_types: [ "workshops_and_courses" ]
   start: 2015-08-23 10:16:33
   end: 2015-08-24 18:07:46
   sponsors: ['Amazon', 'GitHub', 'Google']
-  venue: Kilburn Building
   city: Manchester
   county: Greater Manchester
   country: United Kingdom

--- a/test/fixtures/venues.yml
+++ b/test/fixtures/venues.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/integration/bioschemas_test.rb
+++ b/test/integration/bioschemas_test.rb
@@ -50,7 +50,7 @@ class BioschemasTest < ActionDispatch::IntegrationTest
     end
     results = graph.query(q)
     assert_equal 1, results.count
-    assert_equal '100, Lygon Street', results.first.street_address
+    # assert_equal '100, Lygon Street', results.first.street_address
     assert_equal 'Carlton', results.first.locality
     assert_equal 'Australia', results.first.country
     assert_equal '3010', results.first.postcode
@@ -67,13 +67,13 @@ class BioschemasTest < ActionDispatch::IntegrationTest
     assert_equal 'FundingCorp', results.first.funder
 
     # Organizer
-    q = RDF::Query.new do
-      pattern RDF::Query::Pattern.new(event_uri, RDF::Vocab::SCHEMA.organizer, :organizer_info)
-      pattern RDF::Query::Pattern.new(:organizer_info, RDF::Vocab::SCHEMA.name, :organizer)
-    end
-    results = graph.query(q)
-    assert_equal 1, results.count
-    assert_equal 'EventsCo', results.first.organizer
+    # q = RDF::Query.new do
+    #   pattern RDF::Query::Pattern.new(event_uri, RDF::Vocab::SCHEMA.organizer, :organizer_info)
+    #   pattern RDF::Query::Pattern.new(:organizer_info, RDF::Vocab::SCHEMA.name, :organizer)
+    # end
+    # results = graph.query(q)
+    # assert_equal 1, results.count
+    # assert_equal 'EventsCo', results.first.organizer
   end
 
   test 'Course/CourseInstance & Event bioschemas on show page for course event' do
@@ -155,7 +155,7 @@ class BioschemasTest < ActionDispatch::IntegrationTest
     end
     results = graph.query(q)
     assert_equal 1, results.count
-    assert_equal 'Kilburn Building', results.first.street_address
+    # assert_equal 'Kilburn Building', results.first.street_address
     assert_equal 'Manchester', results.first.locality
     assert_equal 'Greater Manchester', results.first.region
     assert_equal 'United Kingdom', results.first.country
@@ -176,13 +176,13 @@ class BioschemasTest < ActionDispatch::IntegrationTest
     assert_includes sponsors, 'GitHub'
 
     # Organizer
-    q = RDF::Query.new do
-      pattern RDF::Query::Pattern.new(course_instance_uri, RDF::Vocab::SCHEMA.organizer, :organizer_info)
-      pattern RDF::Query::Pattern.new(:organizer_info, RDF::Vocab::SCHEMA.name, :organizer)
-    end
-    results = graph.query(q)
-    assert_equal 1, results.count
-    assert_equal 'CourseCo', results.first.organizer
+    # q = RDF::Query.new do
+    #   pattern RDF::Query::Pattern.new(course_instance_uri, RDF::Vocab::SCHEMA.organizer, :organizer_info)
+    #   pattern RDF::Query::Pattern.new(:organizer_info, RDF::Vocab::SCHEMA.name, :organizer)
+    # end
+    # results = graph.query(q)
+    # assert_equal 1, results.count
+    # assert_equal 'CourseCo', results.first.organizer
   end
 
   test 'Bioschemas on event index page' do

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -4,7 +4,7 @@ require 'sidekiq/testing'
 class EventTest < ActiveSupport::TestCase
   setup do
     @event = events(:one)
-    @mandatory = { start: @event.start, end: @event.end, organizer: @event.organizer,
+    @mandatory = { start: @event.start, end: @event.end,
                    timezone: @event.timezone, contact: @event.contact, eligibility: @event.eligibility,
                    host_institutions: @event.host_institutions }
   end

--- a/test/models/event_venue_test.rb
+++ b/test/models/event_venue_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EventVenueTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/venue_test.rb
+++ b/test/models/venue_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class VenueTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/unit/dictionaries_test.rb
+++ b/test/unit/dictionaries_test.rb
@@ -74,9 +74,6 @@ class DictionariesTest < ActiveSupport::TestCase
     assert_nil dic.lookup(key), "#{key}: invalid key was found?"
     key = 'free'
     assert_not_nil dic.lookup(key), "#{key}: key not found"
-    key = 'hosts'
-    assert_not_nil dic.lookup(key), "#{key}: key not found"
-    assert_equal 'Cost to non-members', dic.lookup(key)['title'], "#{key}: title not matched"
     key = 'charge'
     assert_not_nil dic.lookup(key), "#{key}: key not found"
     assert_equal 'This event has an associated charge for participants.', dic.lookup(key)['description'],

--- a/test/unit/ingestors/bioschemas_ingestor_test.rb
+++ b/test/unit/ingestors/bioschemas_ingestor_test.rb
@@ -28,7 +28,7 @@ class BioschemasIngestorTest < ActiveSupport::TestCase
     assert_includes sample.description, 'This course will give an introduction to the concept of Neural Networks'
     assert_equal '2023-03-20T00:00:00Z', sample.start.utc.iso8601
     assert_equal '2023-03-24T00:00:00Z', sample.end.utc.iso8601
-    assert_equal 'SciLifeLab Uppsala - Navet, Husargatan 3', sample.venue
+    # assert_equal 'SciLifeLab Uppsala - Navet, Husargatan 3', sample.venue
     assert_equal 'Uppsala', sample.city
     assert_equal 'Sweden', sample.country
     assert_equal @content_provider, sample.content_provider

--- a/test/unit/ingestors/event_csv_ingestor_test.rb
+++ b/test/unit/ingestors/event_csv_ingestor_test.rb
@@ -65,7 +65,6 @@ class EventCsvIngestorTest < ActiveSupport::TestCase
     assert_equal DateTime.new(2022, 3, 3, 15, 30, 0), event.end
     assert_equal 'Sydney', event.timezone
     assert_equal 'training.nci@anu.edu.au', event.contact
-    assert_equal 'NCI', event.organizer
     check_array event.eligibility, ['by_invitation'], ['open_to_all']
     check_array event.host_institutions, ['NCI'], ['Intersect']
     refute event.online?

--- a/test/unit/ingestors/eventbrite_ingestor_test.rb
+++ b/test/unit/ingestors/eventbrite_ingestor_test.rb
@@ -46,7 +46,6 @@ class EventbriteIngestorTest < ActiveSupport::TestCase
     event = get_event nil, title, url
     refute_nil event
     assert_equal desc, event.description
-    assert_equal 'ARDC', event.organizer # organizer.name ARDC
     assert_empty event.event_types # format.name other
     assert_equal 'Perth', event.timezone
     assert_equal Time.utc(2022, 4, 11, 12, 0, 0).to_s, event.start.to_s
@@ -56,7 +55,6 @@ class EventbriteIngestorTest < ActiveSupport::TestCase
     assert_equal 'free', event.cost_basis
     assert_nil event.cost_currency # as cost_basis is free
     assert_empty event.keywords
-    assert_nil event.venue
 
     # check completed event
     # eventbrite.id: 291075754417
@@ -84,7 +82,6 @@ class EventbriteIngestorTest < ActiveSupport::TestCase
     event = get_event nil, title, url
     refute_nil event
     assert_equal desc, event.description
-    assert_equal 'Australian Research Data Commons', event.organizer
     assert_equal 'Sydney', event.timezone
     assert_equal Time.utc(2022, 5, 3, 13, 30, 0), event.start
     assert_equal Time.utc(2022, 5, 3, 15, 0, 0), event.end
@@ -115,7 +112,6 @@ class EventbriteIngestorTest < ActiveSupport::TestCase
     event = get_event nil, title, url
     refute_nil event
     assert_equal desc, event.description
-    assert_equal 'Australian Research Data Commons', event.organizer
     assert_equal 'Sydney', event.timezone
     assert_equal Time.utc(2022, 6, 1, 13, 0, 0), event.start
     assert_equal Time.utc(2022, 6, 1, 15, 0, 0), event.end
@@ -135,7 +131,6 @@ class EventbriteIngestorTest < ActiveSupport::TestCase
     event = get_event nil, title, url
     refute_nil event
     assert_equal desc, event.description
-    assert_equal 'Australian Research Data Commons', event.organizer
     assert_equal 'Sydney', event.timezone
     assert_equal Time.utc(2022, 5, 3, 13, 30, 0), event.start
     assert_equal Time.utc(2022, 5, 3, 15, 0, 0), event.end

--- a/test/unit/ingestors/libcal_ingestor_test.rb
+++ b/test/unit/ingestors/libcal_ingestor_test.rb
@@ -49,7 +49,6 @@ class LibcalIngestorTest < ActiveSupport::TestCase
     assert_equal new_url, event.url
 
     # check other fields
-    assert_equal 'Rick Vermunt', event.organizer
     assert_equal Time.zone.parse('Mon, 10 Jan 2022 13:00:00.000000000 UTC +00:00'), event.start
     assert_equal Time.zone.parse('Mon, 10 Jan 2022 15:00:00.000000000 UTC +00:00'), event.end
     assert_equal '', event.venue

--- a/test/unit/ingestors/tess_event_ingestor_test.rb
+++ b/test/unit/ingestors/tess_event_ingestor_test.rb
@@ -50,7 +50,6 @@ class TessEventIngestorTest < ActiveSupport::TestCase
     assert_equal 'Another Portal Provider', event.content_provider.title
     assert_equal 'UTC', event.timezone
     assert_equal 'Melissa Burke (melissa@biocommons.org.au)', event.contact
-    assert_equal 'Australian BioCommons', event.organizer
     assert_equal 1, event.eligibility.size, 'event eligibility size not matched!'
     assert event.eligibility.include?('registration_of_interest')
     assert_equal 1, event.host_institutions.size

--- a/test/unit/ingestors/utwente_ingestor_test.rb
+++ b/test/unit/ingestors/utwente_ingestor_test.rb
@@ -50,7 +50,6 @@ class UtwenteIngestorTest < ActiveSupport::TestCase
 
     # check other fields
     assert_equal 'Amsterdam', event.timezone
-    assert_equal 'University of Twente', event.organizer
     assert_equal Time.zone.parse('Thu, 09 Nov 2023 00:00:00 +0000'), event.start
     assert_equal Time.zone.parse('Thu, 09 Nov 2023 00:00:00 +0000'), event.end
     assert_equal 'Waaier', event.venue


### PR DESCRIPTION
**Summary of changes**

- Adding the venues in the event page with database relation
- removing the organization and venue text field from the event from frontend and backend
- changes in UI by commenting on the fields mentioned in the ticket

**Motivation and context**

[ticket link](https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/72)
 
**Screenshots**

![image](https://github.com/SciLifeLab-TrainingHub-Platform/TeSS/assets/22519506/5ff768e5-ec75-4152-9814-05ff7ff91cf5)

