### PR TITLE
#172 | Need_to_implement_the_city_field_search_for_events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -58,7 +58,9 @@ class Event < ApplicationRecord
       string :title
       string :sponsors, multiple: true
       string :venue
-      string :city
+      string :city, multiple: true do
+        cities.pluck(:name)
+      end
       string :country
       string :event_types, multiple: true do
         EventTypeDictionary.instance.values_for_search(event_types)


### PR DESCRIPTION
ticket:

- [#172_Need_to_implement_the_city_field_search_for_events](https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/172)

**note:** after deployment we need to re-index the solr searchable by running the following command 
`bundle exec rake sunspot:reindex`