### PR TITLE
add branch name tag to dev env image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - rc-*
-      - harshita_workflow-addBranchTag
   create:
     tags:
       - 'rc-v*'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - rc-*
+      - harshita_workflow-addBranchTag
   create:
     tags:
       - 'rc-v*'
@@ -54,6 +55,7 @@ jobs:
       id: determine-env
       run: |
         CURRENT_DATE=$(date +%Y-%m-%d-%H-%M-%S)
+        BRANCH_NAME=$(echo "${{ github.ref_name }}" | sed 's/refs\/heads\///' | tr '/' '-')
         # Define the environment configuration JSON directly in a variable
         ENV_CONFIG='{
           "dev": {
@@ -61,7 +63,7 @@ jobs:
             "SENDER_EMAIL": "${{ secrets.DEV_SENDER_EMAIL }}",
             "DELIVERY_METHOD": "${{ secrets.DEV_DELIVERY_METHOD }}",
             "DOCKER_TARGET": "development",
-            "IMAGE_TAG": "'"$CURRENT_DATE"'"
+            "IMAGE_TAG": "'"$CURRENT_DATE-$BRANCH_NAME"'"
           },
           "preprod": {
             "VARIABLE_VALUE": "${{ secrets.PREPROD_BASE_URL }}",


### PR DESCRIPTION
It was getting very difficult to identify the image in the dev env so added the branch name tag to identify specific images in the registry.
[Issue 70](https://app.zenhub.com/workspaces/th-deployment-658028ba67b50d136affb630/issues/zh/70)