### PR TITLE
Hide_Timezone_Field_on_Event_Show_Page#234

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -60,7 +60,7 @@
           <strong class="text-primary"> Date: </strong>
           <%= neatly_printed_date_range(@event.start, @event.end, false) %>
         </p>
-        <%= display_attribute(@event, :timezone) %>
+        <%#= display_attribute(@event, :timezone) %>
         <%= display_attribute(@event, :duration) %>
 
         <!-- Field: description -->


### PR DESCRIPTION
**Summary of changes**

- ticket: [Hide Timezone Field on Event Show Page#234](https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/234)

As per discussion on slack, commented out the line showing the timezone

![image](https://github.com/user-attachments/assets/de3d36ac-ab72-4029-8c7d-5f74589823b7)
