### PR TITLE
adeel | Hide time zone in event show page #234

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -61,7 +61,7 @@
           <strong class="text-primary"> Date: </strong>
           <%= neatly_printed_date_range(@event.start, @event.end, false) %>
         </p>
-        <%= display_attribute(@event, :timezone) %>
+        <%#= display_attribute(@event, :timezone) %>
         <%= display_attribute(@event, :duration) %>
         <%= display_attribute(@event, :language) { |value| render_language_name(value) } %>
 


### PR DESCRIPTION
ticket 

- [Hide Timezone Field on Event Show Page#234](https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/234)