### PR TITLE
Hide register button for content provider

### DIFF
--- a/app/views/content_providers/index.html.erb
+++ b/app/views/content_providers/index.html.erb
@@ -8,14 +8,18 @@
 
   <div id="content">
     <h2><%=t("features.content_providers.long")%></h2>
-    <% content_for :buttons do %>
+    <%
+=begin%>
+ <% content_for :buttons do %> 
       <%= link_to new_content_provider_path, class: 'btn btn-primary' do %>
         <%= t('register.buttons.content_providers') %>
       <% end %>
       <%= info_button("What are content providers in #{TeSS::Config.site['title_short']}?", hide_text: true) do %>
         <%= render_markdown(ContentProvidersHelper::CONTENT_PROVIDERS_INFO) %>
       <% end %>
-    <% end %>
+    <% end %>  
+<%
+=end%>
 
     <%= render partial: "search/common/search_panel", locals: { resources: @content_providers_results,
                                                                 resource_type: ContentProvider } %>

--- a/app/views/content_providers/index.html.erb
+++ b/app/views/content_providers/index.html.erb
@@ -8,6 +8,7 @@
 
   <div id="content">
     <h2><%=t("features.content_providers.long")%></h2>
+    <%#Commented the below lines to hide register button for content providers%>
     <%
 =begin%>
  <% content_for :buttons do %> 


### PR DESCRIPTION
**Summary of changes**
- Hide the register content provider button and info icon so by commenting it out.

**Motivation and changes**
We don't want end users to add the content provider themselves and therefore hiding the button but not disabling the route because we want ourselves to add the content provider just like how we are doing it at present for events in production.

Checklist

-  [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
-  [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
to license it to the TeSS codebase under the
[BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).