### PR TITLE
Show event page, learning objective renamed to learning outcomes #282

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -127,6 +127,7 @@ class Event < ApplicationRecord
     # :nocov:
   end
 
+  alias_attribute(:learning_outcomes, :learning_objectives)
   attr_accessor :new_venues
   attr_accessor :new_cities
   enum presence: { onsite: 0, online: 1, hybrid: 2 }

--- a/app/views/common/_extra_metadata.html.erb
+++ b/app/views/common/_extra_metadata.html.erb
@@ -29,7 +29,7 @@
   <%= display_attribute(resource, :postcode) %>
 
   <%= display_attribute(resource, :prerequisites, markdown: true) %>
-  <%= display_attribute(resource, :learning_objectives, markdown: true) %>
+  <%= display_attribute(resource, :learning_outcomes, markdown: true) %>
   <%= display_attribute(resource, :eligibility) { |e| EligibilityDictionary.instance.lookup_value(e, 'title') } %>
 
   <%= display_attribute(resource, :host_institutions) { |values| values.join(', ') } %>


### PR DESCRIPTION
**Summary of changes**

- Add alias for learning objective on model
- Use that alias in show page events

Ticket 
- [On show event page, learning objective should be renamed to learning outcomes](https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/282)
