### PR TITLE
Target Audience field not visible Admin_console | #271

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -36,6 +36,13 @@ class Event < ApplicationRecord
     configure :learning_objectives do
       label 'learning outcomes'
     end
+    configure :target_audience, :serialized do
+      label 'Target Audience'
+      help 'Enter items either as an array (e.g., [Students, Teachers, Researchers]) or in the specified format, with each item on a new line starting with a dash (-).'
+      pretty_value do
+        value.join(', ') if value.present?
+      end
+    end
   end
 
 


### PR DESCRIPTION
Ticket
- [Target Audience field is not visible on Admin console#271](https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/271)

Additional notes
- Strict validation is intentionally omitted as this field is primarily used in the admin console for administrative purposes and developer testing.