### PR TITLE
Need_a_separate_field_for_Registration_form_URL | #286

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -299,7 +299,7 @@ class EventsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def event_params
-    params.require(:event).permit(:external_id, :title, :subtitle, :url, :last_scraped, :scraper_record,
+    params.require(:event).permit(:external_id, :title, :subtitle, :url, :last_scraped, :registration_form_url, :scraper_record,
                                   :description, { :topic_ids => [] }, { scientific_topic_names: [] }, { scientific_topic_uris: [] },
                                   { operation_names: [] }, { operation_uris: [] }, { event_types: [] },
                                   { keywords: [] }, { fields: [] }, :start, :end, :application_deadline, :duration, { sponsors: [] },

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -168,6 +168,7 @@ class Event < ApplicationRecord
 
   validates :title, :url, presence: true
   validates :url, url: true
+  validates :registration_form_url, url: true, allow_blank: true
   validates :capacity, numericality: { greater_than_or_equal_to: 1 }, allow_blank: true
   validates :cost_value, numericality: { greater_than: 0 }, allow_blank: true
   validates :event_types, controlled_vocabulary: { dictionary: 'EventTypeDictionary' }

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -44,6 +44,18 @@
   <!-- Field: Application deadline -->
   <%= f.input :application_deadline, as: :datetime_picker, input_html: { title: t('events.hints.application_deadline') } %>
 
+  <!-- Field: registration_form_url -->
+  <%= f.label :registration_form_url, class: "control-label", label: 'Registration form URL' %>
+  <span class="glyphicon" style="cursor: default; font-size: small" title="<%= t('events.hints.registration_form_url_hint') %>">&#xe086;</span>
+  <%=
+    f.input :registration_form_url,
+            input_html: {
+              type: 'url',
+              title: t('events.hints.registration_form_url')
+            },
+            label: false
+  %>
+
   <!-- Field: Timezone -->
   <%= f.input :timezone, as: :time_zone, priority: priority_time_zones,
               input_html: { class: 'js-select2', title: t('events.hints.timezone') } %>
@@ -174,7 +186,7 @@
   <!-- Field: Content Providers -->
   <%#= f.input :content_provider_id, label: 'Content provider (Training Organizer)', collection: current_user.get_editable_providers, label_method: :title, value_method: :id, include_blank: true %>
   <div class="field">
-    <%= f.label :content_provider_ids, "* Content Provider(s)", class: "control-label"%>
+    <%= f.label :content_provider_ids, "* Content Provider(s)", class: "control-label" %>
     <span class="glyphicon"
           style="cursor: default; font-size: small;"
           title="<%= t('events.hints.content_provider_hint') %>">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -56,6 +56,10 @@
       </div>
 
       <div class="my-3">
+        <% if @event.registration_form_url.present? %>
+            <strong>Registration form:</strong>
+            <%= link_to 'Click here to register for the event', @event.registration_form_url, target: '_blank', rel: 'noopener' %>
+        <% end %>
         <!-- Field: start and end -->
         <p class="date no-spacing">
           <strong class="text-primary"> Date: </strong>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -543,6 +543,8 @@ en:
       eligibility: 'Who can attend the training event?'
       end: 'When does the event end?'
       application_deadline: 'Application deadline for the event.'
+      registration_form_url: 'Enter the registration URL for the event.'
+      registration_form_url_hint: 'Enter the full registration URL where participants can sign up for the event.'
       event_type: 'Select the most appropriate event type for the training event.'
       fields: 'Select Fields of Research to better classify your event.'
       hosts: ''

--- a/db/migrate/20250710133947_add_registration_form_url_to_events.rb
+++ b/db/migrate/20250710133947_add_registration_form_url_to_events.rb
@@ -1,0 +1,5 @@
+class AddRegistrationFormUrlToEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :events, :registration_form_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-
-
-
 ActiveRecord::Schema[7.0].define(version: 2025_07_23_130821) do 
 
   # These are extensions that must be enabled in order to support this database

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_03_28_132625) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_10_133947) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -94,6 +94,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_28_132625) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "country_code"
   end
 
   create_table "collaborations", id: :serial, force: :cascade do |t|
@@ -271,6 +272,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_28_132625) do
     t.datetime "application_deadline"
     t.integer "event_status", default: 0, null: false
     t.text "admin_notes"
+    t.string "registration_form_url"
     t.index ["llm_interaction_id"], name: "index_events_on_llm_interaction_id"
     t.index ["presence"], name: "index_events_on_presence"
     t.index ["slug"], name: "index_events_on_slug", unique: true

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -29,7 +29,7 @@ one:
   prerequisites: "You should be awake."
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
-
+  registration_form_url: http://example.com
 
 two:
   external_id: MyString2
@@ -59,6 +59,7 @@ two:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 month_long_event:
   title: Month-long event
@@ -80,6 +81,7 @@ month_long_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 year_long_event:
   title: Year-long event
@@ -101,6 +103,7 @@ year_long_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 iann_event:
   title: iAnn event
@@ -116,6 +119,7 @@ iann_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 scraper_user_event:
   title: material owned by scraper
@@ -136,6 +140,7 @@ scraper_user_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 event_with_external_resource:
   title: External Resource Event
@@ -155,6 +160,7 @@ event_with_external_resource:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 event_with_no_start:
   title: No Start Time
@@ -173,6 +179,7 @@ event_with_no_start:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 event_with_no_end:
   title: No End Time
@@ -191,6 +198,7 @@ event_with_no_end:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 online_event_with_no_end:
   title: No End Time
@@ -210,6 +218,7 @@ online_event_with_no_end:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 organisation_event:
   title: Fun Training Day
@@ -229,6 +238,7 @@ organisation_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 portal_event:
   presence: 0
@@ -250,6 +260,7 @@ portal_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 dodgy_country_event:
   title: Fun Training Day
@@ -269,6 +280,7 @@ dodgy_country_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 no_description_event:
   title: All you need to know is in the title
@@ -287,6 +299,7 @@ no_description_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 event_with_report:
   title: This event happened
@@ -309,6 +322,7 @@ event_with_report:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 another_event_with_report:
   title: This event happened
@@ -329,6 +343,7 @@ another_event_with_report:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 shadowbanned_event:
   external_id: MyString1
@@ -356,6 +371,7 @@ shadowbanned_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 failing_event:
   title: Collision With Iceberg
@@ -377,6 +393,7 @@ failing_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 kilburn:
   title: Kilburn Event
@@ -398,6 +415,7 @@ kilburn:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 calendar_event:
   title: "calendar event"
@@ -423,6 +441,7 @@ calendar_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 training_event:
   title: "calendar event"
@@ -450,7 +469,7 @@ training_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
-
+  registration_form_url: http://example.com
 
 ical_event_1:
   title: P'Con - Embracing new solutions for in-situ visualisation
@@ -475,6 +494,7 @@ ical_event_1:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 ical_event_2:
   title: "PaCER Seminar: Computational Fluid Dynamics"
@@ -499,6 +519,7 @@ ical_event_2:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 course_event:
   title: Summer Course on Learning Stuff
@@ -527,6 +548,7 @@ course_event:
   language: "en"
   prerequisites: "You should be awake."
   cost_basis: "2 monies for students, 5 monies for everyone else"
+  registration_form_url: http://example.com
 
 hybrid_event:
   presence: 2
@@ -543,6 +565,7 @@ hybrid_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 approved_event:
   title: approved event
@@ -559,6 +582,7 @@ approved_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 awaiting_review_event:
   title: awaiting review event
@@ -575,6 +599,7 @@ awaiting_review_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 declined_event:
   title: declined event
@@ -591,6 +616,7 @@ declined_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com
 
 revisions_required_event:
   title: revisions required event
@@ -607,3 +633,4 @@ revisions_required_event:
   target_audience: ['Everyone!']
   cost_basis: "2 monies for students, 5 monies for everyone else"
   learning_objectives: "There are some."
+  registration_form_url: http://example.com

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -797,4 +797,66 @@ class EventTest < ActiveSupport::TestCase
       event.save
     end
   end
+
+  test 'registration_form_url allows valid URLs' do
+    valid_urls = %w[http://example.com https://example.com https://sub.domain.co.uk/path?query=123 https://example.com:8080 https://example.com/path#anchor https://user:pass@example.com]
+
+    valid_urls.each do |valid_url|
+      parameters = @mandatory.merge({
+                                      user: users(:regular_user),
+                                      title: 'Valid event',
+                                      url: 'https://main.example.com',
+                                      online: true,
+                                      registration_form_url: valid_url
+                                    })
+
+      event = Event.new(parameters)
+      event.validate
+
+      assert_empty event.errors[:registration_form_url], "Expected '#{valid_url}' to be valid, but got: #{event.errors[:registration_form_url].join(', ')}"
+      end
+  end
+
+  test 'registration_form_url rejects invalid URLs' do
+    invalid_urls = [
+      'just-text',
+      'www.example.com',                  # missing scheme
+      'http:/incomplete.com',             # malformed scheme
+      'http//missing-colon.com',          # missing colon after http
+      '://missing-scheme.com',            # missing scheme name
+      'ftp://example.com',                # disallowed scheme if only http/https allowed
+      'https:// example.com',             # space in URL
+    ]
+
+    invalid_urls.each do |invalid_url|
+      parameters = @mandatory.merge({
+                                      user: users(:regular_user),
+                                      title: 'Invalid URL event',
+                                      url: 'https://main.example.com',
+                                      online: true,
+                                      registration_form_url: invalid_url
+                                    })
+
+      event = Event.new(parameters)
+      event.validate
+
+      refute_empty event.errors[:registration_form_url], "Expected '#{invalid_url}' to be invalid, but no errors were found"
+    end
+  end
+
+  test 'registration_form_url allows blank URL' do
+    parameters = @mandatory.merge({
+                                    user: users(:regular_user),
+                                    title: 'Blank URL event',
+                                    url: 'https://example.com/event',
+                                    online: true,
+                                    registration_form_url: ''  # Blank URL
+                                  })
+
+    event = Event.new(parameters)
+    event.validate
+
+    assert_empty event.errors[:registration_form_url], 'Expected blank registration_form_url to be allowed, but got validation errors'
+
+  end
 end


### PR DESCRIPTION
ticket: https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/286

- Introduced a new field: registration_form_url in the Events model.
- Added URL validation for the new field, allowing blank values.
- Updated the admin panel and event forms (both new and edit) to include the registration_form_url field.
- Displayed the registration_form_url on the event show page as a clickable link.
- Added test cases to validate:
  - Acceptance of valid URLs
  - Rejection of invalid URLs
  - Allowance of blank values for the registration_form_url


3 new test cases are added to test run the following commands for each

- `docker compose run test rake test TEST=test/models/event_test.rb TESTOPTS="--name=test_registration_form_url_allows_blank_URL" > /Users/adeel/Downloads/temp/test_output.txt`
- `docker compose run test rake test TEST=test/models/event_test.rb TESTOPTS="--name=test_registration_form_url_rejects_invalid_URLs" > /Users/adeel/Downloads/temp/test_output.txt`
- `docker compose run test rake test TEST=test/models/event_test.rb TESTOPTS="--name=test_registration_form_url_allows_valid_URLs" > /Users/adeel/Downloads/temp/test_output.txt`

p.s. change this path (/Users/adeel/Downloads/temp/test_output.txt) according to your setup



<img width="3374" height="1328" alt="e1-SciLifeLab-Training-Portal" src="https://github.com/user-attachments/assets/bbc05090-e7c1-4187-bb31-4a11e81360f6" />
<img width="3374" height="6772" alt="Edit-event-SciLifeLab-Training-Portal" src="https://github.com/user-attachments/assets/37b3dc54-a1e6-43f2-b35f-9445648e16c6" />
