### PR TITLE
Added banner to distinguish between servers #294

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,12 +1,15 @@
 <%# header notice -%>
 <% if TeSS::Config.header_notice&.strip.present? %>
-  <nav class="header-notice">
-    <div class="container">
-      <div class="text-center">
-        <%== TeSS::Config.header_notice %>
+  <% unless Rails.env.production? %>
+    <nav class="header-notice">
+      <div class="container">
+        <div class="text-center">
+          <%== TeSS::Config.header_notice %>
+          <%= Rails.env %>
+        </div>
       </div>
-    </div>
-  </nav>
+    </nav>
+  <% end %>
 <% end %>
 
 <header class="unified-header">
@@ -54,7 +57,7 @@
             { feature: 'trainers', link: trainers_path },
             { feature: 'content_providers', link: content_providers_path },
             # { feature: 'nodes', link: nodes_path },
-            { feature: 'our_resources', link: our_resources_path}
+            { feature: 'our_resources', link: our_resources_path }
           ].select do |t|
             t[:feature] == 'about' || TeSS::Config.feature[t[:feature]]
           end.sort_by do |t|

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,14 +1,16 @@
 <%# header notice -%>
-<% if TeSS::Config.header_notice&.strip.present? %>
-  <% unless Rails.env.production? %>
-    <nav class="header-notice">
-      <div class="container">
-        <div class="text-center">
-          <%== TeSS::Config.header_notice %>
-        </div>
+<% if TeSS::Config.header_notice&.strip.present? &&
+  ENV['DEPLOYMENT_ENV'].present? &&
+  ENV['DEPLOYMENT_ENV'] != 'live'
+%>
+  <nav class="header-notice">
+    <div class="container">
+      <div class="text-center">
+        <%== TeSS::Config.header_notice %>
+        <%== ENV['DEPLOYMENT_ENV'] %>
       </div>
-    </nav>
-  <% end %>
+    </div>
+  </nav>
 <% end %>
 
 <header class="unified-header">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,7 +7,6 @@
     <div class="container">
       <div class="text-center">
         <%== TeSS::Config.header_notice %>
-        <%== ENV['DEPLOYMENT_ENV'] %>
       </div>
     </div>
   </nav>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -5,7 +5,6 @@
       <div class="container">
         <div class="text-center">
           <%== TeSS::Config.header_notice %>
-          <%= Rails.env %>
         </div>
       </div>
     </nav>

--- a/config/tess.yml
+++ b/config/tess.yml
@@ -53,7 +53,7 @@ default: &default
     zoom:
       latitude: 3
       longitude: 13
-  header_notice: # HTML to display above the header
+  header_notice: You are using a non-production version of this site. Information may be modified or deleted without prior warning.
   feature:
     elearning_materials: false
     events: true

--- a/docker/tess.docker-test.yml
+++ b/docker/tess.docker-test.yml
@@ -49,7 +49,7 @@ default: &default
     zoom:
       latitude: 3
       longitude: 13
-  header_notice: # HTML to display above the header
+  header_notice: You are using a non-production version of this site. Information may be modified or deleted without prior warning.
   feature:
     elearning_materials: false
     events: true

--- a/env.sample
+++ b/env.sample
@@ -26,3 +26,6 @@ REDIS_TEST_URL=redis://redis:6379/0
 SLACK_BOT_USER_OAUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxx
 # use comma-separated values if more than 1 channel is needed
 SLACK_COURSE_NOTIFICATION_CHANNELS="#channel1,#channel2"
+
+# Deployment environment: can be one of 'dev', 'preprod', or 'live'
+DEPLOYMENT_ENV=dev

--- a/test/config/test_tess.yml
+++ b/test/config/test_tess.yml
@@ -34,7 +34,7 @@ default: &default
     zoom:
       latitude: 3
       longitude: 13
-  header_notice:
+  header_notice: You are using a non-production version of this site. Information may be modified or deleted without prior warning.
   feature:
     elearning_materials: true
     events: true


### PR DESCRIPTION
Ticket: [Banner needs to be added to distinguish between servers (dev, pre-prod) NOT LIVE)#294](https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/294)

@harshita3199  **IMPORTANT: Please add DEPLOYMENT_ENV=live for our live website**

Changes
- user pre configured header_notice feature to display banner with conditional logic to check server first
- added an env variable for distinguishing between servers ('dev', 'preprod', or 'live')


--- 

Screen shot(s)
<img width="2394" height="1246" alt="image" src="https://github.com/user-attachments/assets/a44b10c8-caf7-4150-95d9-b01a40466b32" />

