### PR TITLE
update design on Training assets page #304

### DIFF
--- a/app/assets/stylesheets/resources.scss
+++ b/app/assets/stylesheets/resources.scss
@@ -89,21 +89,7 @@
   }
 }
 
-.guide_page_category {
-  display: none;
-  @media screen and (max-width: 991.98px) {
-    display: block;
-  }
-}
-
-.guide_page_category.active {
-  display: block;
-}
-
-
-
 #trainer_community_accordion {
-
   .panel-heading {
     background-color: #a8c946;
   }

--- a/app/views/our_resources/_guide_sidebar.html.erb
+++ b/app/views/our_resources/_guide_sidebar.html.erb
@@ -18,18 +18,9 @@
 
 <script>
     function guide_sidebar_show_item(elementClicked) {
-        let allGuideCategories = document.getElementsByClassName('guide_page_category');
-        for (let i = 0; i < allGuideCategories.length; i++) {
-            allGuideCategories[i].classList.remove('active');
-        }
-
         let targetElementId = elementClicked.getAttribute('href').substring(1);
         let targetElement = document.getElementById(targetElementId);
-
-        if (targetElement) {
-            targetElement.classList.add('active');
-        }
-        document.getElementById(elementClicked.href.split('#')[1]).scrollIntoView();
+        document.getElementById(elementClicked.href.split('#')[1]).scrollIntoView({ behavior: 'smooth', block: 'start' });
         return false;
     }
 </script>

--- a/app/views/our_resources/guides.html.erb
+++ b/app/views/our_resources/guides.html.erb
@@ -11,9 +11,8 @@
 
   <div class="container">
     <div class="content">
-      <% first_category_key = guides.keys.first %>
       <% guides.each do |category_key, category| %>
-        <div id="<%= category_key %>" class="guide_page_category <%= 'active' if category_key == first_category_key %>">
+        <div id="<%= category_key %>">
           <h4><%= category['name'] %></h4>
           <p><%= category['description'] %></p>
           <br>


### PR DESCRIPTION
Ticket: [Update design on Training assets page #304](https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/304)

Changes:
- Mostly UI-related (no test case required).
- Updated the Guides – Training Assets page:
  - All guides are now displayed on the page.
  - Clicking a side menu option smoothly scrolls the browser to the corresponding section.

ScreenShot

<img width="3136" height="5908" alt="Screenshot 2025-08-18 at 16-27-45 Training Assets - SciLifeLab Training Portal" src="https://github.com/user-attachments/assets/5256f9b3-63e2-4ed6-8276-f8421776c206" />
