### PR TITLE
disable the link preview

### DIFF
--- a/app/jobs/slack_notification_job.rb
+++ b/app/jobs/slack_notification_job.rb
@@ -11,7 +11,7 @@ class SlackNotificationJob < ApplicationJob
     client = Slack::Web::Client.new
     channels.each do |channel|
       begin
-        client.chat_postMessage(channel: channel, text: message, as_user: true)
+        client.chat_postMessage(channel: channel, text: message, as_user: true, unfurl_links: false)
         Rails.logger.info("Slack notification sent successfully to '#{channel}'")
       rescue Slack::Web::Api::Errors::SlackError => e
         Rails.logger.error("Slack notification failed for '#{channel}': #{e.message}")


### PR DESCRIPTION
**Summary of changes**

- At present, whenever the th-bot publishes the course announcement then it shows link preview of that course which doesn't looks good so disabling them

**Motivation and context**

(#273 )
 


**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
