### PR TITLE
Fix dev race: enqueue event emails after transaction commit (create + approval)

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -27,8 +27,8 @@ class Event < ApplicationRecord
   before_save :geocoding_cache_lookup, if: :address_will_change?
   before_create :update_event_statuses
   after_save :enqueue_geocoding_worker, if: :address_changed?
-  after_create :set_status_and_notify
-  after_update :change_status_and_notify_user
+  after_commit :set_status_and_notify, on: :create
+  after_commit :change_status_and_notify_user, on: :update
   after_save :notify_slack_if_published
 
   # rails admin settings


### PR DESCRIPTION
**Summary Changes**
  - Move after_create :set_status_and_notify → after_commit :set_status_and_notify, on: :create
  - Move after_update :change_status_and_notify_user → after_commit :change_status_and_notify_user, on: :update

Fixes an ActiveJob race in development where emails triggered on create (trusted user auto-approval) could run before the Event was committed, causing “Couldn’t find Event with 'id'” errors.

**Rationale**
      - The Async queue adapter in dev can execute deliver_later immediately, in a separate thread/connection that cannot see uncommitted rows/associations.
      - Using after_commit ensures the Event (and its associations) are fully persisted and visible when the job deserializes GlobalIDs and renders templates.
      - We applied the same safeguard to approval-change emails for consistency and to avoid subtle stale-read issues.

**Behavior Notes**
      - Trusted user create: User and Content Provider emails enqueue after commit; no deserialization errors.
      - Admin approval: Emails enqueue after commit; user counter/role updates occur successfully (now as part of post-commit processing).
      - Slack notifications are unchanged (still only on status transitions to approved).

**Validation**
Reproduced locally: creation and approval flows now enqueue jobs only after COMMIT; no “Couldn’t find Event …”.