### PR TITLE
integrate matomo analytics 

### DIFF
--- a/app/views/common/_cookie_info.html.erb
+++ b/app/views/common/_cookie_info.html.erb
@@ -1,6 +1,6 @@
 <p>
   <%= t('cookies.notice') %>
-  <%= t('cookies.google_analytics') if TeSS::Config.analytics_enabled %>
+  <%= t('cookies.matomo_analytics') if TeSS::Config.analytics_enabled %>
 </p>
 <p>
   See our <%= link_to 'Privacy Policy', privacy_path %> for more information.

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -21,7 +21,13 @@
   <% end -%>
 
   <% if TeSS::Config.analytics_enabled && cookie_consent.allow_tracking? %>
-    <%= render 'layouts/google_analytics' %>
+    <%
+=begin%>
+ <%= render 'layouts/google_analytics' %> 
+<%
+=end%>
+   <%= render 'layouts/matomo_analytics' %>
+
   <% end %>
 
   <% if content_for? :og_header %>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -21,8 +21,8 @@
   <% end -%>
 
   <% if TeSS::Config.analytics_enabled && cookie_consent.allow_tracking? %>
-    <%= render 'layouts/google_analytics' if Rails.application.secrets.google_analytics_code.present? %>
-    <%= render 'layouts/matomo_analytics' if Rails.application.secrets.matomo_url.present? %>
+    <%= render 'layouts/google_analytics' %>
+    <%= render 'layouts/matomo_analytics' %>
   <% end %>
 
   <% if content_for? :og_header %>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -21,7 +21,6 @@
   <% end -%>
 
   <% if TeSS::Config.analytics_enabled && cookie_consent.allow_tracking? %>
-    <%= render 'layouts/google_analytics' %>
     <%= render 'layouts/matomo_analytics' %>
   <% end %>
 

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -21,13 +21,8 @@
   <% end -%>
 
   <% if TeSS::Config.analytics_enabled && cookie_consent.allow_tracking? %>
-    <%
-=begin%>
- <%= render 'layouts/google_analytics' %> 
-<%
-=end%>
-   <%= render 'layouts/matomo_analytics' %>
-
+    <%= render 'layouts/google_analytics' if Rails.application.secrets.google_analytics_code.present? %>
+    <%= render 'layouts/matomo_analytics' if Rails.application.secrets.matomo_url.present? %>
   <% end %>
 
   <% if content_for? :og_header %>

--- a/app/views/layouts/_matomo_analytics.html.erb
+++ b/app/views/layouts/_matomo_analytics.html.erb
@@ -16,7 +16,7 @@
   
   // Load Matomo tracking script
   (function() {
-    var u="<%= Rails.application.secrets.matomo_url %>";
+    var u="<%= Rails.application.secrets.matomo_url.to_s.chomp('/') + '/' %>";
     _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '<%= Rails.application.secrets.matomo_site_id %>']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];

--- a/app/views/layouts/_matomo_analytics.html.erb
+++ b/app/views/layouts/_matomo_analytics.html.erb
@@ -1,13 +1,25 @@
 <!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  
+  // Track initial page view
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
+  
+  // Turbolinks compatibility: track page changes
+  document.addEventListener('turbolinks:load', function() {
+    if (typeof _paq !== 'undefined') {
+      _paq.push(['setCustomUrl', window.location.href]);
+      _paq.push(['setDocumentTitle', document.title]);
+      _paq.push(['trackPageView']);
+    }
+  });
+  
+  // Load Matomo script
   (function() {
-    var u="https://matomo.dc.scilifelab.se/";
+    var u="<%= Rails.application.secrets.matomo_url %>";
     _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '13']);
+    _paq.push(['setSiteId', '<%= Rails.application.secrets.matomo_site_id %>']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();

--- a/app/views/layouts/_matomo_analytics.html.erb
+++ b/app/views/layouts/_matomo_analytics.html.erb
@@ -2,11 +2,10 @@
 <script>
   var _paq = window._paq = window._paq || [];
   
-  // Track initial page view
-  _paq.push(['trackPageView']);
+  // Enable link tracking
   _paq.push(['enableLinkTracking']);
   
-  // Turbolinks compatibility: track page changes
+  // Track page views on every Turbolinks navigation (including initial load)
   document.addEventListener('turbolinks:load', function() {
     if (typeof _paq !== 'undefined') {
       _paq.push(['setCustomUrl', window.location.href]);
@@ -15,7 +14,7 @@
     }
   });
   
-  // Load Matomo script
+  // Load Matomo tracking script
   (function() {
     var u="<%= Rails.application.secrets.matomo_url %>";
     _paq.push(['setTrackerUrl', u+'matomo.php']);

--- a/app/views/layouts/_matomo_analytics.html.erb
+++ b/app/views/layouts/_matomo_analytics.html.erb
@@ -1,5 +1,5 @@
 <!-- Matomo -->
-<script>
+<script id="matomo-script">
   var _paq = window._paq = window._paq || [];
   
   // Enable link tracking

--- a/app/views/layouts/_matomo_analytics.html.erb
+++ b/app/views/layouts/_matomo_analytics.html.erb
@@ -1,0 +1,15 @@
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://matomo.dc.scilifelab.se/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '13']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->

--- a/config/application.rb
+++ b/config/application.rb
@@ -89,7 +89,7 @@ module TeSS
     def analytics_enabled
       force_analytics_enabled || 
       (Rails.application.secrets.google_analytics_code.present? && Rails.env.production?) ||
-      Rails.application.secrets.matomo_url.present?
+      (Rails.application.secrets.matomo_url.present? && ENV['DEPLOYMENT_ENV'] == 'live')
     end
 
     def map_enabled

--- a/config/application.rb
+++ b/config/application.rb
@@ -87,8 +87,7 @@ module TeSS
     end
 
     def analytics_enabled
-      force_analytics_enabled || 
-      (Rails.application.secrets.google_analytics_code.present? && Rails.env.production?) ||
+      force_analytics_enabled || (Rails.application.secrets.google_analytics_code.present? && Rails.env.production?) ||
       (Rails.application.secrets.matomo_url.present? && ENV['DEPLOYMENT_ENV'] == 'live')
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -87,9 +87,12 @@ module TeSS
     end
 
     def analytics_enabled
-      force_analytics_enabled || 
-      (Rails.application.secrets.google_analytics_code.present? && Rails.env.production?) ||
-      (Rails.application.secrets.matomo_url.present? && Rails.application.secrets.matomo_site_id.present? && Rails.env.production? && ENV['DEPLOYMENT_ENV'] == 'live')
+      return true if force_analytics_enabled
+
+      matomo_configured = Rails.application.secrets.matomo_url.present? &&
+                          Rails.application.secrets.matomo_site_id.present?
+
+      matomo_configured && Rails.env.production? && ENV['DEPLOYMENT_ENV'] == 'live'
     end
 
     def map_enabled

--- a/config/application.rb
+++ b/config/application.rb
@@ -87,7 +87,9 @@ module TeSS
     end
 
     def analytics_enabled
-      force_analytics_enabled || (Rails.application.secrets.google_analytics_code.present? && Rails.env.production?)
+      force_analytics_enabled || 
+      (Rails.application.secrets.google_analytics_code.present? && Rails.env.production?) ||
+      Rails.application.secrets.matomo_url.present?
     end
 
     def map_enabled

--- a/config/application.rb
+++ b/config/application.rb
@@ -87,8 +87,9 @@ module TeSS
     end
 
     def analytics_enabled
-      force_analytics_enabled || (Rails.application.secrets.google_analytics_code.present? && Rails.env.production?) ||
-      (Rails.application.secrets.matomo_url.present? && Rails.application.secrets.matomo_site_id.present? && Rails.env.production? && ENV['DEPLOYMENT_ENV'] == 'preprod')
+      force_analytics_enabled || 
+      (Rails.application.secrets.google_analytics_code.present? && Rails.env.production?) ||
+      (Rails.application.secrets.matomo_url.present? && Rails.application.secrets.matomo_site_id.present? && Rails.env.production? && ENV['DEPLOYMENT_ENV'] == 'live')
     end
 
     def map_enabled

--- a/config/application.rb
+++ b/config/application.rb
@@ -88,7 +88,7 @@ module TeSS
 
     def analytics_enabled
       force_analytics_enabled || (Rails.application.secrets.google_analytics_code.present? && Rails.env.production?) ||
-      (Rails.application.secrets.matomo_url.present? && ENV['DEPLOYMENT_ENV'] == 'live')
+      (Rails.application.secrets.matomo_url.present? && Rails.application.secrets.matomo_site_id.present? && Rails.env.production? && ENV['DEPLOYMENT_ENV'] == 'preprod')
     end
 
     def map_enabled

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -717,7 +717,7 @@ en:
       not_source_enabled: 'Source not enabled.'
   cookies:
     notice: TeSS makes use of some necessary cookies to provide its core functionality.
-    google_analytics: Additionally, we make use of analytics to discover how people are using TeSS in order to help us improve the service. To opt out of this, choose the "Allow necessary cookies" option.
+    matomo_analytics: Additionally, we make use of analytics to discover how people are using TeSS in order to help us improve the service. To opt out of this, choose the "Allow necessary cookies" option.
     necessary_cookies_btn: Only allow necessary cookies
     all_cookies_btn: Allow all cookies
     no_consent: No cookie consent provided

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -717,12 +717,12 @@ en:
       not_source_enabled: 'Source not enabled.'
   cookies:
     notice: TeSS makes use of some necessary cookies to provide its core functionality.
-    google_analytics: Additionally, we make use of Google Analytics to discover how people are using TeSS in order to help us improve the service. To opt out of this, choose the "Allow necessary cookies" option.
+    google_analytics: Additionally, we make use of analytics to discover how people are using TeSS in order to help us improve the service. To opt out of this, choose the "Allow necessary cookies" option.
     necessary_cookies_btn: Only allow necessary cookies
     all_cookies_btn: Allow all cookies
     no_consent: No cookie consent provided
     options:
-      tracking: Cookies required for Google Analytics, to help TeSS improve its service.
+      tracking: Cookies required for analytics tracking, to help TeSS improve its service.
       necessary: Cookies necessary for TeSS to function, for example to provide user-authentication and forgery protection.
     buttons:
       revoke: Revoke cookie consent

--- a/config/locales/overrides/traininghub.en.yml
+++ b/config/locales/overrides/traininghub.en.yml
@@ -349,7 +349,7 @@ en:
     resources: "The details of any training materials and events that you register will be publicly visible and searchable. Any workflows and packages created can be opted to be made private, in which case only you, any collaborators you specify, and the <b>Service</b> administrators will be able to view and search for them."
     server: "When you browse the <b>Service</b>, the server automatically records logs of which pages you access, when you accessed them, and your IP address. These logs are used to fix errors and are not shared with any third parties. Sensitive information (such as passwords) is automatically stripped out."
     cookies: The <b>Service</b> makes use of "strictly necessary cookies" for the site to function. These cookies are needed to establish your "session" with the <b>Service</b>, which allows functionality such as user log-in, and secures against Cross Site Request Forgery (CSRF) attacks.
-    analytics: "TeSS uses Google Analytics to track how users are discovering the portal and interacting with the <b>Service</b>. The information gathered includes which pages you visited, which search terms lead you to the <b>Service</b> and information about your web browser. No personally identifiable information is sent to Google."
+    analytics: "The portal uses Matomo analytics to track how users are discovering the portal and interacting with the <b>Service</b>. The information gathered includes which pages you visited, which search terms lead you to the <b>Service</b> and information about your web browser. This data is stored on our own servers and is not shared with third parties."
     retention: "Your information will be retained by the <b>Service</b> until you choose to remove it, you delete your account, the <b>Service</b> ceases to exist, or when stipulated by the archival rules for the university as a government authority. If you want to update or remove your personal data, please contact SciLifeLab Training Hub at Stockholm University using traininghub@scilifelab.se."
     code: ""
     controller: ""
@@ -523,12 +523,12 @@ en:
       not_source_enabled: 'Source not enabled.'
   cookies:
     notice: SciLifeLab Training Portal makes use of some necessary cookies to provide its core functionality.
-    google_analytics: Additionally, we make use of Google Analytics to discover how people are using TeSS in order to help us improve the service. To opt out of this, choose the "Allow necessary cookies" option.
+    matomo_analytics: Additionally, we make use of Matomo analytics to discover how people are using the Training Portal in order to help us improve the service. To opt out of this, choose the "Allow necessary cookies" option.
     necessary_cookies_btn: Only allow necessary cookies
     all_cookies_btn: Allow all cookies
     no_consent: No cookie consent provided
     options:
-      tracking: Cookies required for Google Analytics, to help TeSS improve its service.
+      tracking: Cookies required for Matomo analytics, to help the Training Portal improve its service.
       necessary: Cookies necessary for SciLifeLab Training Portal to function, for example to provide user-authentication and forgery protection.
     buttons:
       revoke: Revoke cookie consent

--- a/config/secrets.example.yml
+++ b/config/secrets.example.yml
@@ -14,6 +14,8 @@
 external_api_keys: &external_api_keys
   google_analytics_code:
   google_maps_api_key:
+  matomo_url:
+  matomo_site_id:
   recaptcha:
     sitekey: <%= ENV["RECAPTCHA_SITE_KEY"] %>
     secret:  <%= ENV["RECAPTCHA_SECRET_KEY"] %>
@@ -75,6 +77,8 @@ production:
     :enable_starttls_auto: true
   google_analytics_code: <%= ENV["PRODUCTION_GANAL_CODE"] %>
   google_maps_api_key:   <%= ENV["PRODUCTION_GMAPS_KEY"] %>
+  matomo_url:            <%= ENV["MATOMO_URL"] %>
+  matomo_site_id:        <%= ENV["MATOMO_SITE_ID"] %>
   database:
     :host: localhost
     :name: tess_production

--- a/config/secrets.example.yml
+++ b/config/secrets.example.yml
@@ -14,8 +14,6 @@
 external_api_keys: &external_api_keys
   google_analytics_code:
   google_maps_api_key:
-  matomo_url:
-  matomo_site_id:
   recaptcha:
     sitekey: <%= ENV["RECAPTCHA_SITE_KEY"] %>
     secret:  <%= ENV["RECAPTCHA_SECRET_KEY"] %>

--- a/docs/matomo-analytics-integration.md
+++ b/docs/matomo-analytics-integration.md
@@ -4,12 +4,12 @@ This document describes how Matomo analytics tracking is integrated into Trainin
 
 ## Overview
 
-Training Portal uses [Matomo](https://matomo.org/) for web analytics tracking. The integration is designed to:
+Training Portal uses Matomo (https://matomo.org/) for web analytics tracking. The integration is designed to:
 
 - Respect user privacy and cookie consent
 - Only track production traffic (no development/staging pollution)
 - Work with Turbolinks navigation
-- Be easily configurable per deployment environment
+- Be easily configurable
 
 ## Architecture
 
@@ -18,9 +18,9 @@ Training Portal uses [Matomo](https://matomo.org/) for web analytics tracking. T
 ```
 1. User visits page
 2. Check: TeSS::Config.analytics_enabled?
-   ├─ Environment check: DEPLOYMENT_ENV == 'live'?
-   ├─ Configuration check: Matomo URL/Site ID present?
-   └─ Manual override: force_analytics_enabled?
+   - Environment check: DEPLOYMENT_ENV == 'live'?
+   - Configuration check: Matomo URL/Site ID present?
+   - Manual override: force_analytics_enabled?
 3. Check: User consented to tracking cookies?
 4. If both true: Load Matomo tracking script
 5. Track page views and navigation via Turbolinks events
@@ -44,20 +44,15 @@ For **production** deployment, set these environment variables:
 DEPLOYMENT_ENV=live
 
 # Matomo server configuration (REQUIRED)
-MATOMO_URL=""
-MATOMO_SITE_ID=""
-```
-
-For **non-production** deployments:
-
-```bash
-# Disable analytics tracking
-DEPLOYMENT_ENV=dev        # or 'preprod' for pre-production
+MATOMO_URL="https://your-matomo-instance.com/"
+MATOMO_SITE_ID="your_production_site_id"
 ```
 
 ### Rails Configuration
 
 The Matomo configuration is handled in `config/secrets.yml`:
+
+**For Production** (from environment variables):
 
 ```yaml
 production:
@@ -86,22 +81,10 @@ Matomo only loads when:
 
 The consent system offers two options:
 
-- **"Allow necessary cookies"**: Essential cookies only, no analytics
-- **"Allow all cookies"**: Includes analytics tracking
+- **Allow necessary cookies**: Essential cookies only, no analytics
+- **Allow all cookies**: Includes analytics tracking
 
 ## Testing
-
-### Local Development Testing
-
-1. **Verify analytics are disabled**:
-
-   ```bash
-   rails console
-   TeSS::Config.analytics_enabled  # Should return false
-   ENV['DEPLOYMENT_ENV']           # Should be 'dev' or nil
-   ```
-
-2. **Check page source**: Search for "Matomo" - should find nothing
 
 ### Production Testing
 
@@ -118,7 +101,7 @@ The consent system offers two options:
    - Visit site and accept "Allow all cookies"
    - Navigate between pages
    - Check browser Network tab for requests to matomo instance url
-   - Verify in Matomo dashboard: Visitors → Real-time
+   - Verify in Matomo dashboard (production site): Visitors → Real-time
 
 3. **Test cookie consent**:
    - "Allow necessary cookies" → No Matomo requests
@@ -146,15 +129,8 @@ The consent system offers two options:
 
    ```bash
    rails console
-   TeSS::Config.analytics_enabled  # Should be true
+   TeSS::Config.analytics_enabled  # Should return true
    ```
-
-### Tracking Development/Staging Traffic
-
-If you see non-production traffic in Matomo:
-
-- Verify `DEPLOYMENT_ENV` is set correctly on all environments
-- Check that analytics are properly disabled in non-production
 
 ### Cookie Consent Issues
 
@@ -183,16 +159,3 @@ If you see non-production traffic in Matomo:
 2. Restart Rails application
 3. Verify new configuration in Rails console
 4. Test tracking functionality
-
-### Monitoring
-
-- Monitor Matomo dashboard for data quality
-- Check error logs for JavaScript errors
-- Verify tracking across different user flows
-- Review cookie consent acceptance rates
-
-## External Resources
-
-- [Matomo Documentation](https://developer.matomo.org/)
-- [Matomo JavaScript Tracking API](https://developer.matomo.org/api-reference/tracking-javascript)
-- [GDPR Compliance with Matomo](https://matomo.org/docs/privacy/)

--- a/docs/matomo-analytics-integration.md
+++ b/docs/matomo-analytics-integration.md
@@ -1,0 +1,198 @@
+# Matomo Analytics Integration
+
+This document describes how Matomo analytics tracking is integrated into Training Portal and how to configure it for different environments.
+
+## Overview
+
+Training Portal uses [Matomo](https://matomo.org/) for web analytics tracking. The integration is designed to:
+
+- Respect user privacy and cookie consent
+- Only track production traffic (no development/staging pollution)
+- Work with Turbolinks navigation
+- Be easily configurable per deployment environment
+
+## Architecture
+
+### Analytics Logic Flow
+
+```
+1. User visits page
+2. Check: TeSS::Config.analytics_enabled?
+   ├─ Environment check: DEPLOYMENT_ENV == 'live'?
+   ├─ Configuration check: Matomo URL/Site ID present?
+   └─ Manual override: force_analytics_enabled?
+3. Check: User consented to tracking cookies?
+4. If both true: Load Matomo tracking script
+5. Track page views and navigation via Turbolinks events
+```
+
+### Key Components
+
+- **Environment Detection**: Uses `DEPLOYMENT_ENV` environment variable
+- **Configuration**: Matomo URL and Site ID from Rails secrets
+- **Cookie Consent**: Integrated with existing TeSS cookie consent system
+- **Turbolinks Compatibility**: Tracks navigation between pages
+
+## Configuration
+
+### Environment Variables Required
+
+For **production** deployment, set these environment variables:
+
+```bash
+# Enable analytics tracking (REQUIRED)
+DEPLOYMENT_ENV=live
+
+# Matomo server configuration (REQUIRED)
+MATOMO_URL=""
+MATOMO_SITE_ID=""
+```
+
+For **non-production** deployments:
+
+```bash
+# Disable analytics tracking
+DEPLOYMENT_ENV=dev        # or 'preprod' for pre-production
+```
+
+### Rails Configuration
+
+The Matomo configuration is handled in `config/secrets.yml`:
+
+```yaml
+production:
+  matomo_url: <%= ENV["MATOMO_URL"] %>
+  matomo_site_id: <%= ENV["MATOMO_SITE_ID"] %>
+```
+
+### Analytics Enablement Logic
+
+In `config/application.rb`, the `analytics_enabled` method determines when tracking is active:
+
+```ruby
+def analytics_enabled
+  force_analytics_enabled || 
+  (Rails.application.secrets.google_analytics_code.present? && Rails.env.production?) ||
+  (Rails.application.secrets.matomo_url.present? && ENV['DEPLOYMENT_ENV'] == 'live')
+end
+```
+
+### Cookie Consent Integration
+
+Matomo only loads when:
+
+1. Analytics are enabled (`TeSS::Config.analytics_enabled`)
+2. User has consented to tracking cookies (`cookie_consent.allow_tracking?`)
+
+The consent system offers two options:
+
+- **"Allow necessary cookies"**: Essential cookies only, no analytics
+- **"Allow all cookies"**: Includes analytics tracking
+
+## Testing
+
+### Local Development Testing
+
+1. **Verify analytics are disabled**:
+
+   ```bash
+   rails console
+   TeSS::Config.analytics_enabled  # Should return false
+   ENV['DEPLOYMENT_ENV']           # Should be 'dev' or nil
+   ```
+
+2. **Check page source**: Search for "Matomo" - should find nothing
+
+### Production Testing
+
+1. **Verify analytics are enabled**:
+
+   ```bash
+   # On production server
+   rails console
+   TeSS::Config.analytics_enabled  # Should return true
+   ENV['DEPLOYMENT_ENV']           # Should be 'live'
+   ```
+
+2. **Test tracking flow**:
+   - Visit site and accept "Allow all cookies"
+   - Navigate between pages
+   - Check browser Network tab for requests to matomo instance url
+   - Verify in Matomo dashboard: Visitors → Real-time
+
+3. **Test cookie consent**:
+   - "Allow necessary cookies" → No Matomo requests
+   - "Allow all cookies" → Matomo requests visible
+
+## Troubleshooting
+
+### Analytics Not Working
+
+1. **Check environment variable**:
+
+   ```bash
+   echo $DEPLOYMENT_ENV  # Should be 'live' for production
+   ```
+
+2. **Check Matomo configuration**:
+
+   ```bash
+   rails console
+   Rails.application.secrets.matomo_url.present?     # Should be true
+   Rails.application.secrets.matomo_site_id.present? # Should be true
+   ```
+
+3. **Check analytics enablement**:
+
+   ```bash
+   rails console
+   TeSS::Config.analytics_enabled  # Should be true
+   ```
+
+### Tracking Development/Staging Traffic
+
+If you see non-production traffic in Matomo:
+
+- Verify `DEPLOYMENT_ENV` is set correctly on all environments
+- Check that analytics are properly disabled in non-production
+
+### Cookie Consent Issues
+
+- Ensure cookie consent system is working properly
+- Check browser console for JavaScript errors
+- Verify cookie banner appears for new users
+
+## Security and Privacy
+
+### Data Protection
+
+- Analytics only track users who explicitly consent
+- No tracking occurs in development/staging environments
+- IP addresses are handled according to Matomo configuration
+- No personally identifiable information is sent to analytics
+
+### GDPR Compliance
+
+- Users can opt out via "Allow necessary cookies"
+- Cookie preferences can be changed at any time
+- Clear notice about analytics usage provided
+
+### Updating Matomo Configuration
+
+1. Update environment variables on production server
+2. Restart Rails application
+3. Verify new configuration in Rails console
+4. Test tracking functionality
+
+### Monitoring
+
+- Monitor Matomo dashboard for data quality
+- Check error logs for JavaScript errors
+- Verify tracking across different user flows
+- Review cookie consent acceptance rates
+
+## External Resources
+
+- [Matomo Documentation](https://developer.matomo.org/)
+- [Matomo JavaScript Tracking API](https://developer.matomo.org/api-reference/tracking-javascript)
+- [GDPR Compliance with Matomo](https://matomo.org/docs/privacy/)

--- a/docs/production.md
+++ b/docs/production.md
@@ -293,3 +293,17 @@ If this doesn't work, you may need to first enable "linger" on the `tess` user, 
 You can then start/stop/restart Sidekiq using the following:
 
     systemctl --user {start,stop,restart} sidekiq
+
+## Analytics Configuration
+
+Training Portal includes Matomo analytics integration for production traffic tracking. For detailed setup instructions, see:
+
+- [Matomo Analytics Integration](matomo-analytics-integration.md)
+
+**Quick setup**: Set these environment variables for production:
+
+```bash
+DEPLOYMENT_ENV=live
+MATOMO_URL=https://your-matomo-instance.com/
+MATOMO_SITE_ID=your_site_id
+```

--- a/env.sample
+++ b/env.sample
@@ -29,3 +29,8 @@ SLACK_COURSE_NOTIFICATION_CHANNELS="#channel1,#channel2"
 
 # Deployment environment: can be one of 'dev', 'preprod', or 'live'
 DEPLOYMENT_ENV=dev
+
+# Matomo Analytics
+# Get these values from your Matomo instance
+MATOMO_URL=https://your-matomo-instance.com/
+MATOMO_SITE_ID=1

--- a/test/integration/cookie_consent_integration_test.rb
+++ b/test/integration/cookie_consent_integration_test.rb
@@ -57,7 +57,7 @@ class CookieConsentIntegrationTest < ActionDispatch::IntegrationTest
       get root_path
 
       assert_equal ['necessary'], CookieConsent.new(cookies).options
-      assert_select '#ga-script', count: 0
+      assert_select '#matomo-script', count: 0
     end
   end
 
@@ -68,7 +68,7 @@ class CookieConsentIntegrationTest < ActionDispatch::IntegrationTest
       get root_path
 
       assert CookieConsent.new(cookies).allow_tracking?
-      assert_select '#ga-script', count: 1
+      assert_select '#matomo-script', count: 1
     end
   end
 
@@ -81,7 +81,7 @@ class CookieConsentIntegrationTest < ActionDispatch::IntegrationTest
       cookie_consent = CookieConsent.new(cookies)
       assert_equal ['necessary'], cookie_consent.options
       assert cookie_consent.allow_tracking?
-      assert_select '#ga-script', count: 1
+      assert_select '#matomo-script', count: 1
     end
   end
 
@@ -105,7 +105,7 @@ class CookieConsentIntegrationTest < ActionDispatch::IntegrationTest
 
       assert_response :success
       assert_select '#cookie-consent-level', text: /No cookie consent/, count: 0
-      assert_select '#cookie-consent-level li', text: /Cookies required for Google Analytics/, count: 0
+      assert_select '#cookie-consent-level li', text: /Cookies required for Matomo analytics/, count: 0
       assert_select '#cookie-consent-level li', text: /Cookies necessary/
 
       post cookies_consent_path, params: { allow: all_options }
@@ -113,7 +113,7 @@ class CookieConsentIntegrationTest < ActionDispatch::IntegrationTest
       get cookies_consent_path
 
       assert_response :success
-      assert_select '#cookie-consent-level li', text: /Cookies required for Google Analytics/
+      assert_select '#cookie-consent-level li', text: /Cookies required for Matomo analytics/
       assert_select '#cookie-consent-level li', text: /Cookies necessary/
     end
   end
@@ -136,7 +136,7 @@ class CookieConsentIntegrationTest < ActionDispatch::IntegrationTest
       get cookies_consent_path
       assert_response :success
 
-      assert_select '#cookie-consent-level li', text: /Cookies required for Google Analytics/
+      assert_select '#cookie-consent-level li', text: /Cookies required for Matomo analytics/
       assert_select '#cookie-consent-level li', text: /Cookies necessary/
     end
   end
@@ -161,7 +161,7 @@ class CookieConsentIntegrationTest < ActionDispatch::IntegrationTest
       assert_response :success
 
       assert_select '#cookie-consent-level', text: /No cookie consent/, count: 0
-      assert_select '#cookie-consent-level li', text: /Cookies required for Google Analytics/, count: 0
+      assert_select '#cookie-consent-level li', text: /Cookies required for Matomo analytics/, count: 0
       assert_select '#cookie-consent-level li', text: /Cookies necessary/
       assert_select '#cookie-banner', count: 0
 
@@ -173,7 +173,7 @@ class CookieConsentIntegrationTest < ActionDispatch::IntegrationTest
       assert_response :success
 
       assert_select '#cookie-consent-level', text: /No cookie consent/
-      assert_select '#cookie-consent-level li', text: /Cookies required for Google Analytics/, count: 0
+      assert_select '#cookie-consent-level li', text: /Cookies required for Matomo analytics/, count: 0
       assert_select '#cookie-consent-level li', text: /Cookies necessary/, count: 0
       assert_select '#cookie-banner'
     end


### PR DESCRIPTION
This PR is related to setting up analytics for the portal. 
It relates to issue #337 

Question: I had this confusion if I should completely remove google analytics code or not but then I thought let's start with Matomo and later one we can remove the google analytics stale code if we decide to go with Matomo only for longer run, but open for suggestion (if you think code should not be there, I am happy to remove it)