### PR TITLE
Minor Updates/Optimisations

### DIFF
--- a/app/views/layouts/_matomo_analytics.html.erb
+++ b/app/views/layouts/_matomo_analytics.html.erb
@@ -16,7 +16,7 @@
   
   // Load Matomo tracking script
   (function() {
-    var u="<%= Rails.application.secrets.matomo_url %>";
+    var u="<%= Rails.application.secrets.matomo_url.to_s.chomp('/') + '/' %>";
     _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '<%= Rails.application.secrets.matomo_site_id %>']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];

--- a/config/application.rb
+++ b/config/application.rb
@@ -87,9 +87,12 @@ module TeSS
     end
 
     def analytics_enabled
-      force_analytics_enabled || 
-      (Rails.application.secrets.google_analytics_code.present? && Rails.env.production?) ||
-      (Rails.application.secrets.matomo_url.present? && Rails.application.secrets.matomo_site_id.present? && Rails.env.production? && ENV['DEPLOYMENT_ENV'] == 'live')
+      return true if force_analytics_enabled
+
+      matomo_configured = Rails.application.secrets.matomo_url.present? &&
+                          Rails.application.secrets.matomo_site_id.present?
+
+      matomo_configured && Rails.env.production? && ENV['DEPLOYMENT_ENV'] == 'live'
     end
 
     def map_enabled

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -717,7 +717,7 @@ en:
       not_source_enabled: 'Source not enabled.'
   cookies:
     notice: TeSS makes use of some necessary cookies to provide its core functionality.
-    google_analytics: Additionally, we make use of analytics to discover how people are using TeSS in order to help us improve the service. To opt out of this, choose the "Allow necessary cookies" option.
+    matomo_analytics: Additionally, we make use of analytics to discover how people are using TeSS in order to help us improve the service. To opt out of this, choose the "Allow necessary cookies" option.
     necessary_cookies_btn: Only allow necessary cookies
     all_cookies_btn: Allow all cookies
     no_consent: No cookie consent provided


### PR DESCRIPTION
TLDR: Tighten script, normalise base URL string, update local

  - Tightened config/application.rb:89-94 to require Matomo secrets (unless forced) before enabling analytics, preventing GA-only configs from loading an empty Matomo snippet
  - Normalised matomo base URL to avoid malformed script URLs when the env var lacks a trailing slash.
  - Updated config/locales/en.yml:718-725 so the cookie banner has a matomo_analytics string
