### PR TITLE
updating hint fields for course CRUD

### DIFF
--- a/app/views/courses/_authors_fields.html.erb
+++ b/app/views/courses/_authors_fields.html.erb
@@ -1,5 +1,6 @@
 <fieldset class="authors-fields border">
-  <legend class="w-auto">Author(s)</legend>
+  <legend class="w-auto">Author(s) <span class="glyphicon" style="cursor: default; font-size: small" title="<%= t('courses.hints.authors_hint') %>">&#xe086;</span></legend>
+
 
   <!-- Hidden field to hold serialized authors -->
   <%= f.hidden_field :authors, id: 'course_authors' %>

--- a/app/views/courses/_contributors_fields.html.erb
+++ b/app/views/courses/_contributors_fields.html.erb
@@ -1,5 +1,5 @@
 <fieldset class="contributors-fields border">
-  <legend class="w-auto">Contributor(s)</legend>
+  <legend class="w-auto">Contributor(s)<span class="glyphicon" style="cursor: default; font-size: small" title="<%= t('courses.hints.contributor_hint') %>">&#xe086;</span></legend>
 
   <!-- Hidden field to hold serialized contributors -->
   <%= f.hidden_field :contributors, id: 'course_contributors' %>

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -6,13 +6,14 @@
   <!-- Field: Title -->
   <div class="form-group">
     <%= f.label :title, class: "control-label" %>
-    <span class="glyphicon" style="cursor: default; font-size: small" title="<%= t('events.hints.title_hint') %>">&#xe086;</span>
-    <%= f.input :title, as: :string, input_html: { title: t('events.hints.title') }, label: false %>
+    <span class="glyphicon" style="cursor: default; font-size: small" title="<%= t('courses.hints.title_hint') %>">&#xe086;</span>
+    <%= f.input :title, as: :string, input_html: { title: t('courses.hints.title_hint') }, label: false %>
   </div>
 
   <!-- Field: URL -->
   <%= render partial: 'common/url_checker',
              locals: { f: f, url: courses_check_exists_path, title: '' } %>
+             
   <!-- Field: Language -->
   <%= f.input :language, collection: LanguageDictionary.instance.options_for_select,
               prompt: t('events.prompts.language'), include_blank: true, input_html: { title: t('events.hints.language') } %>
@@ -29,13 +30,13 @@
   <!-- Field: Description -->
   <%= f.label :description, class: "control-label" %>
   <span class="glyphicon" style="cursor: default; font-size: small" title="<%= t('events.hints.description_hint') %>">&#xe086;</span>
-  <%= f.input :description, as: :markdown_area, input_html: { rows: '5', title: t('events.hints.description') }, label: false %>
+  <%= f.input :description, as: :markdown_area, input_html: { rows: '5', title: t('events.hints.description_hint') }, label: false %>
 
   <!-- Field: Target Audience -->
   <%= f.multi_input :target_audience,
                     errors: @course.errors[:target_audience],
                     title: t('events.hints.targets'),
-                    label: "#{f.label(:target_audience, class: 'control-label')} <span class='glyphicon' style='cursor: default; font-size: small' title='#{t('events.hints.targets_hint')}'> &#xe086;</span>".html_safe %>
+                    label: "#{f.label(:target_audience, class: 'control-label')} <span class='glyphicon' style='cursor: default; font-size: small' title='#{t('events.hints.targets')}'> &#xe086;</span>".html_safe %>
 
   <!-- Field: prerequisites_knowledge -->
   <%= f.label :prerequisites_knowledge, class: "control-label" %>
@@ -45,22 +46,22 @@
   <!-- Field: Prerequisites -->
   <%= f.label :prerequisites_technical, class: "control-label" %>
   <span class="glyphicon" style="cursor: default; font-size: small" title="<%= t('events.hints.prerequisites_hint') %>">&#xe086;</span>
-  <%= f.input :prerequisites_technical, as: :markdown_area, input_html: { rows: '3', title: t('events.hints.prerequisites') }, label: false %>
+  <%= f.input :prerequisites_technical, as: :markdown_area, input_html: { rows: '3', title: t('events.hints.prerequisites_hint') }, label: false %>
 
-  <!-- Field: Prerequisites -->
+  <!-- Field: Structure and Duration -->
   <%= f.label :structure_and_duration, class: "control-label" %>
-  <span class="glyphicon" style="cursor: default; font-size: small" title="<%= t('events.hints.prerequisites_hint') %>">&#xe086;</span>
-  <%= f.input :structure_and_duration, as: :markdown_area, input_html: { rows: '3', title: t('events.hints.prerequisites') }, label: false %>
+  <span class="glyphicon" style="cursor: default; font-size: small" title="<%= t('courses.hints.structure_duration_hint') %>">&#xe086;</span>
+  <%= f.input :structure_and_duration, as: :markdown_area, input_html: { rows: '3', title: t('courses.hints.structure_duration_hint') }, label: false %>
 
   <!-- Field: Learning Objectives-->
   <%= f.label :learning_outcomes, "* Learning outcomes", class: "control-label" %>
   <span class="glyphicon" style="cursor: default; font-size: small" title="<%= t('events.hints.objectives_hint') %>">&#xe086;</span>
-  <%= f.input :learning_outcomes, as: :markdown_area, input_html: { rows: '3', title: t('events.hints.objectives') }, label: false %>
+  <%= f.input :learning_outcomes, as: :markdown_area, input_html: { rows: '3', title: t('events.hints.objectives_hint') }, label: false %>
 
 
   <!-- Field: Keywords -->
   <%= f.multi_input :keywords, errors: @course.errors[:keywords],
-                    title: t('events.hints.keywords'),
+                    title: t('events.hints.keywords_hint'),
                     label: "#{f.label(:keywords, class: 'control-label')} <span class='glyphicon' style='cursor: default; font-size: small' title='#{t('events.hints.keywords_hint')}'> &#xe086;</span>".html_safe %>
 
   <!-- Author fields  Render one Author field by default-->
@@ -75,7 +76,7 @@
     <%= f.label :event_ids, "* Event(s)", class: "control-label" %>
     <span class="glyphicon"
           style="cursor: default; font-size: small;"
-          title="Events for the course">
+          title="<%= t('courses.hints.event_hint') %>">
     &#xe086;
   </span>
     <%= f.collection_select :event_ids, @events, :id, :title,

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -4,7 +4,8 @@
 </div>
 <div class="row">
   <div class="col-md-4 col-md-push-8">
-    soe generic text we can display here to help users
+<div class="info-box-header"><i class="glyphicon glyphicon-info-sign"></i> Editing your course</div>
+    You are editing a course in the SciLifeLab course catalogue. <br><br>This course and all iterations connected to it will be affected by this update!
   </div>
   <div class="col-md-8 col-md-pull-4">
     <%= render :partial => 'form' %>

--- a/app/views/courses/new.html.erb
+++ b/app/views/courses/new.html.erb
@@ -1,10 +1,13 @@
 <%- model_class = Course -%>
 <div class="page-header">
-  <%= page_title("New Course Announcement") %>
+  <%= page_title("New Course Catalogue Entry") %>
 </div>
 <div class="row">
   <div class="col-md-4 col-md-push-8">
-    we can add generic text here for users
+<div class="info-box-header"><i class="glyphicon glyphicon-info-sign"></i> Add a course to the SciLifeLab catalogue</div>
+    The SciLifeLab course catalogue is a listing of all SciLifeLab-affiliated courses. By adding your course here, potential participants can be alerted when the next registration cycle opens, and resources can be efficiently directed into developing courses that target gaps in our national catalogue.
+<br><br>
+To add a course, fill in the form, including all required fields, with as rich information as you can!
   </div>
   <div class="col-md-8 col-md-pull-4">
     <%= render :partial => 'form' %>

--- a/config/locales/overrides/traininghub.en.yml
+++ b/config/locales/overrides/traininghub.en.yml
@@ -366,6 +366,14 @@ en:
     info: >
       Content providers are entities (such as academic institutions, non-profit organisations, portals etc.) that
       provide training materials of relevance to life sciences and ELIXIR.
+  courses:
+    hints: 
+      title_hint: 'The title of your course.'
+      url_hint: 'The URL of your course website.'
+      authors_hint: 'Add the names and persistent identifiers of those who have authored the course.'
+      contributor_hint: 'The names and persistent identifiers of those hwo have contributed to the course material.'
+      event_hint: 'Upcoming instances where this course will be taught or run.'
+      structure_duration_hint: 'The time, in hours, it takes to complete the course, and the format this time will take.'
   events:
     hints:
       address: 'Where is this event being held?'
@@ -410,7 +418,7 @@ en:
       title: 'Add a title for your training event.'
       title_hint: "The title of your course. This can be the same as previous years."
       url: 'Enter a valid URL for the event landing page.'
-      url_hint: "Your course website. This can be the registration form if you do not have a course website."
+      url_hint: "The link to your course website."
       venue_hint: "The room and building your course will take place in."
 
 


### PR DESCRIPTION
Changes made:

1. adding hints for course CRUD operations that are specific to the fields of this form
2. updating hints that appear when mousing over the fields so that they are the same as when mousing over the i icon
3. changes to UI - title of course page, information displayed for user.