### PR TITLE
feature #353 Fix cookie issue for matomo to work for existing users

### DIFF
--- a/app/views/cookies/consent.html.erb
+++ b/app/views/cookies/consent.html.erb
@@ -26,7 +26,7 @@
                       class: 'btn btn-default' %>
         </div>
         <div class="pull-right">
-          <%= link_to t('cookies.buttons.necessary'), cookies_consent_path(allow: 'necessary'),
+          <%= link_to t('cookies.buttons.necessary'), cookies_consent_path(allow: 'necessary_v2'),
                       method: :post, class: 'btn btn-default' %>
           <%= link_to t('cookies.buttons.all'), cookies_consent_path(allow: CookieConsent::OPTIONS.join(',')),
                       method: :post, class: 'btn btn-default' if TeSS::Config.analytics_enabled %>

--- a/app/views/layouts/_cookie_banner.html.erb
+++ b/app/views/layouts/_cookie_banner.html.erb
@@ -10,7 +10,7 @@
       </div>
 
       <div class="col-lg-4 col-md-5 text-right">
-        <%= link_to t('cookies.buttons.necessary'), cookies_consent_path(allow: 'necessary'),
+        <%= link_to t('cookies.buttons.necessary'), cookies_consent_path(allow: 'necessary_v2'),
                     method: :post, class: 'btn btn-default' %>
         <%= link_to t('cookies.buttons.all'), cookies_consent_path(allow: CookieConsent::OPTIONS.join(',')),
                     method: :post, class: 'btn btn-primary' if TeSS::Config.analytics_enabled %>

--- a/lib/cookie_consent.rb
+++ b/lib/cookie_consent.rb
@@ -1,5 +1,5 @@
 class CookieConsent
-  OPTIONS = %w(necessary tracking).freeze
+  OPTIONS = %w(necessary_v2 tracking).freeze
 
   def initialize(store)
     @store = store


### PR DESCRIPTION
**Ticket**

* [Fix cookie issue for matomo to work for existing users](https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/353)

**Summary of changes**
* Updated the cookie options in the class to: `OPTIONS = %w(necessary_v2 tracking).freeze`
* Modified the “necessary” button in the cookie banner to submit the new value: `allow: 'necessary\v2`.

**How it works now**
* Existing users had `cookie_consent = "necessary"`.
* Since "necessary" is no longer valid, their consent is treated as missing.
* The banner is shown again.
* When the user clicks the button, `necessary_v2` is saved in their cookies, the banner disappears, and Matomo tracking can be activated.
* New users automatically get `necessary_v2` stored, so everything works as expected.

**Alternative approach**
* A VERSION-based solution can achieve the same result in a **cleaner, more maintainable, and future-proof** way without renaming cookie options.
