### PR TITLE
Fix nested-list and masonry regressions on Events/Courses pages

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -60,14 +60,19 @@ function redirect_with_updated_search(param, paramVal) {
 }
 
 function reposition_tiles(container, tileClass){
-    var $container = $("." + container);
-    if (!$container.length) return;
+    var $containers = $("." + container);
+    if (!$containers.length) return;
 
-    $container.imagesLoaded(function () {
-        $container.masonry({
-            // options...
-            itemSelector: "." + tileClass,
-            columnWidth: 20
+    $containers.each(function () {
+        var $container = $(this);
+        if (!$container.find("." + tileClass).length) return;
+
+        $container.imagesLoaded(function () {
+            $container.masonry({
+                // options...
+                itemSelector: "." + tileClass,
+                columnWidth: 20
+            });
         });
     });
 }

--- a/app/assets/stylesheets/masonry.scss
+++ b/app/assets/stylesheets/masonry.scss
@@ -5,7 +5,6 @@
   *zoom: 1;
   padding-bottom: 15px;
   padding-left: 0;
-  height: auto !important;
 }
 
 .media-grid:before,

--- a/app/views/content_providers/_content_provider.html.erb
+++ b/app/views/content_providers/_content_provider.html.erb
@@ -1,7 +1,7 @@
 
 <% cache(content_provider, expires_in: 6.hours) do %>
-  <li class="course-card course-card--content-provider <%="long" if TeSS::Config.site.fetch('content_provider_grid_long', true)%>")>
-    <%= link_to content_provider, class: 'course-card__link' do %>
+  <li class="masonry-brick media-item <%="long" if TeSS::Config.site.fetch('content_provider_grid_long', true)%>">
+    <%= link_to content_provider, class: 'link-overlay' do %>
       <%= image_tag content_provider.image.url, class: 'media-image listing_image' %>
 
       <h4 class="mb-2 mt-3"><%= content_provider.title %></h4>

--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -1,6 +1,6 @@
 <% collection_item = local_assigns[:collection_item] %>
 
-<li class="course-card">
+<li class="masonry-brick media-item long course-card">
   <%= item_order_badge(collection_item) if collection_item.present? %>
 
   <div class="course-card__content">
@@ -36,4 +36,6 @@
       <% end %>
     </div>
   </div>
+
+  <%= item_comment(collection_item) if collection_item.present? %>
 </li>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -20,9 +20,7 @@
                locals: { resources: @courses_results, resource_type: Course } %>
 
     <% if @courses.present? %>
-      <ul class="course-cards media-grid">
-        <%= render partial: 'common/masonry_grid', locals: { objects: @courses } %>
-      </ul>
+      <%= render partial: 'common/masonry_grid', locals: { objects: @courses } %>
 
       <div class="courses-index__pagination">
         <%= render partial: "search/common/pagination_bar", locals: { resources: @courses } %>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -3,7 +3,7 @@
 <% presence_label = Event.presences.key?(presence) ? t("activerecord.attributes.event.presence.#{presence}", default: presence.humanize) : nil %>
 <% show_scilifelab_badge = show_scilifelab_badge?(event) %>
 
-<li class="course-card course-card--event">
+<li class="masonry-brick media-item long course-card course-card--event">
   <%= item_order_badge(collection_item) if collection_item.present? %>
 
   <div class="course-card__layout">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -38,9 +38,7 @@
       <% unless @events.blank? %>
         <div class="tab-content">
           <div id="home" class="tab-pane fade in active">
-            <ul class="course-cards media-grid">
-              <%= render partial: 'common/masonry_grid', locals: { objects: @events } %>
-            </ul>
+            <%= render partial: 'common/masonry_grid', locals: { objects: @events } %>
 
             <%= render partial: "search/common/pagination_bar", locals: { resources: @events } %>
           </div>

--- a/app/views/static/home/_upcoming_events.html.erb
+++ b/app/views/static/home/_upcoming_events.html.erb
@@ -2,9 +2,9 @@
   <section id="upcoming_events">
     <div class="tab-content">
       <h2 class="text-center"><%= link_to('Upcoming events', events_path, class: 'home-title-link' ) %></h2>
-      <ul class="tab-pane fade in active">
+      <div class="tab-pane fade in active">
         <%= render partial: 'common/masonry_grid', locals: { objects: @events } %>
-      </ul>
+      </div>
     </div>
   </section>
 <% end %>

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -33,6 +33,9 @@ class CoursesControllerTest < ActionController::TestCase
   test 'courses index cards render as stretched links' do
     get :index
     assert_response :success
+    assert_select 'ul.masonry.media-grid', count: 1
+    assert_select 'ul.course-cards', count: 0
+    assert_select 'ul.masonry.media-grid > ul', count: 0
     assert_select '.course-card', minimum: 1
     assert_select 'a.course-card__stretched-link', minimum: 1
     assert_select '.course-card__title-text', minimum: 1

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -46,6 +46,9 @@ class EventsControllerTest < ActionController::TestCase
     get :index
     assert_response :success
 
+    assert_select '#home > ul.masonry.media-grid', count: 1
+    assert_select '#home > ul.course-cards', count: 0
+    assert_select '#home > ul.masonry.media-grid > ul', count: 0
     assert_select '.course-card--event', minimum: 1
     assert_select 'a.course-card__stretched-link', minimum: 1
     assert_select '.course-card__title-text', minimum: 1


### PR DESCRIPTION
  ## Summary

  Fixes HTML/layout issues with the new courses/event cards.

  - Events and Courses index pages had invalid `<ul>` nested inside `<ul>` (browsers auto-repair this unpredictably)
  - New card items dropped the `.masonry-brick` class that the JS grid initializer looks for, causing zero-height containers
  - A `height: auto !important` CSS hack was added to mask this, but it could break masonry grids on other pages (collections, trainers, etc.)

  ## What this PR does

  1. Removes the outer `<ul>` wrappers that caused invalid nesting (events, courses, home page)
  2. Adds masonry item classes back onto event/course card `<li>` elements (alongside the new card classes)
  3. Reverts the content provider partial to masonry-only markup and fixes a pre-existing stray `)` in its class attribute
  4. Removes the `height: auto !important` override from `.media-grid`
  5. Adds a JS guard so Masonry skips containers that have no `.masonry-brick` children
  6. Restores `item_comment` in the course partial (was dropped during the card rewrite; event partial had it)

  ## Approach

  Minimal compatibility fix — cards now carry both masonry and course-card classes so everything works with the existing Masonry pipeline. A broader "replace Masonry with a
  card-list renderer" refactor is possible later but out of scope here.

  ## Tests

  - Added assertions on events/courses index to prevent nested-`<ul>` regressions
  - Existing content provider masonry tests pass without changes