### PR TITLE
Remove green tick icon for approved courses and events

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -106,7 +106,7 @@ module ApplicationHelper
                                                 when 'awaiting_review'
                                                   ['fa-clock-o', 'awaiting-review', 'Pending review by SciLifeLab administrators.']
                                                 when 'approved'
-                                                  ['fa-check', 'approved', 'Approved by SciLifeLab and now publicly accessible.']
+                                                  return # Approved items now do not show a status badge
                                                 when 'declined'
                                                   ['fa-ban', 'declined', 'Declined by SciLifeLab administrators.']
                                                 when 'revisions_required'


### PR DESCRIPTION
Ticket: https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/385 

Changes: removed the logic for icon for green tick mark and add a helping comment instead

