### PR TITLE
Fix Event(s) remove asterisk and update copy on course form

### DIFF
--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -73,7 +73,7 @@
 
   <!-- Field: Events -->
   <div class="field">
-    <%= f.label :event_ids, "* Event(s)", class: "control-label" %>
+    <%= f.label :event_ids, "Event(s)", class: "control-label" %>
     <span class="glyphicon"
           style="cursor: default; font-size: small;"
           title="<%= t('courses.hints.event_hint') %>">
@@ -89,7 +89,7 @@
       <%= @course.errors[:content_providers].join(', ') %>
     </span>
     <% else %>
-      <span class="help-block small">Choose one or more content provider for the event.</span>
+      <span class="help-block small">Select any potential upcoming instances of your course</span>
     <% end %>
   </div>
 

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -84,6 +84,8 @@ class CoursesControllerTest < ActionController::TestCase
     sign_in @user
     get :new
     assert_response :success
+    assert_select "label[for='course_event_ids']", text: 'Event(s)'
+    assert_select 'span.help-block.small', text: 'Select any potential upcoming instances of your course'
   end
 
   test 'should get new page for logged in users only' do


### PR DESCRIPTION
  ## Summary

  This updates the Event(s) field copy on the course form to match actual behavior and intent.

  ## Changes

  - Changed label from * Event(s) to Event(s) in app/views/courses/_form.html.erb.
  - Changed helper text from Choose one or more content provider for the event. to Select any potential upcoming instances of your course.
  - Added assertions in test/controllers/courses_controller_test.rb (should get new) to verify both texts.
