### PR TITLE
fix postgres version

### DIFF
--- a/.github/workflows/deployment-checks.yml
+++ b/.github/workflows/deployment-checks.yml
@@ -12,17 +12,32 @@ jobs:
       DB_PASSWORD: password
       SECRET_BASE_KEY: test_key
       RAILS_ENV: production
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_DB: ${{ env.DB_NAME }}
+          POSTGRES_USER: ${{ env.DB_USER }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
     steps:
-      - uses: harmon758/postgresql-action@v1
-        with:
-          postgresql db: ${DB_NAME}
-          postgresql user: ${DB_USER}
-          postgresql password: ${DB_PASSWORD}
-        name: Set up database
-
       - uses: actions/checkout@v4
         name: Set up Ruby
-
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true


### PR DESCRIPTION
deployment checks workflow is failing due to the the step which is using old docker client but now the runner needs new version so using postgres service now.

Error Message: `docker: Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.`