### PR TITLE
send_email_notification_when_you_submit_a_course_or_event

### DIFF
--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -220,4 +220,8 @@ module CoursesHelper
       events.select { |event| event.event_status == 'approved' }
     end
   end
+
+  def show_course_revision_notice?(course)
+    course.course_status == Course.course_statuses.key(Course.course_statuses[:revisions_required])
+  end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -224,4 +224,7 @@ module EventsHelper
     end
   end
 
+  def show_event_revision_notice?(event)
+    event.event_status == Event.event_statuses.key(Event.event_statuses[:revisions_required])
+  end
 end

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -148,3 +148,15 @@
                 :back, :class => 'btn btn-default' %>
   </div>
 <% end %>
+
+<% notice = if @course.new_record?
+              { message: t('courses.hints.submission_notice'), class: 'alert-info' }
+            elsif show_course_revision_notice?(@course)
+              { message: t('courses.hints.revision_notice'), class: 'alert-warning' }
+            end %>
+
+<% if notice %>
+  <div class="alert <%= notice[:class] %> mb-4" role="alert">
+    <%= notice[:message] %>
+  </div>
+<% end %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -243,15 +243,23 @@
   <%#= f.multi_input :sponsors, errors: @event.errors[:sponsors], hint: t('events.hints.sponsors') %>
   <%# end %>
 
-  <% if @event.event_status == Event.event_statuses.key(Event.event_statuses[:revisions_required]) %>
-    <p>After updating this event, an email will be sent to the admin to review and approve the changes.</p>
-  <% end %>
-
   <div class="form-group">
     <%= f.submit (f.object.new_record? ? "Add" : "Update") + " event", :class => 'btn btn-primary' %>
     <%= link_to 'Back', :back, class: 'btn btn-default' %>
     <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
                 :back, :class => 'btn btn-default' %>
+  </div>
+<% end %>
+
+<% notice = if @event.new_record?
+              { message: t('events.hints.submission_notice'), class: 'alert-info' }
+            elsif show_event_revision_notice?(@event)
+              { message: t('events.hints.revision_notice'), class: 'alert-warning' }
+            end %>
+
+<% if notice %>
+  <div class="alert <%= notice[:class] %> mb-4" role="alert">
+    <%= notice[:message] %>
   </div>
 <% end %>
 

--- a/config/locales/overrides/traininghub.en.yml
+++ b/config/locales/overrides/traininghub.en.yml
@@ -374,8 +374,8 @@ en:
       contributor_hint: 'The names and persistent identifiers of those hwo have contributed to the course material.'
       event_hint: 'Upcoming instances where this course will be taught or run.'
       structure_duration_hint: 'The time, in hours, it takes to complete the course, and the format this time will take.'
-      submission_notice: "After submitting this course, you will receive a confirmation email acknowledging that your course has been successfully submitted."
-      revision_notice: "After updating this course, an email will be sent to the administrators to notify them."
+      submission_notice: "After submitting this Training catalogue, you will receive a confirmation email acknowledging that your catalogue has been successfully submitted."
+      revision_notice: "After updating this Training catalogue, an email will be sent to the administrators to notify them."
   events:
     hints:
       address: 'Where is this event being held?'
@@ -422,8 +422,8 @@ en:
       url: 'Enter a valid URL for the event landing page.'
       url_hint: "The link to your course website."
       venue_hint: "The room and building your course will take place in."
-      submission_notice: "After submitting this event, you will receive a confirmation email acknowledging that your event has been successfully submitted."
-      revision_notice: "After updating this event, an email will be sent to the administrators to notify them."
+      submission_notice: "After submitting this training session, you will receive a confirmation email acknowledging that your training session has been successfully submitted."
+      revision_notice: "After updating this training session, an email will be sent to the administrators to notify them."
   materials:
     hints:
       authors: >

--- a/config/locales/overrides/traininghub.en.yml
+++ b/config/locales/overrides/traininghub.en.yml
@@ -374,6 +374,8 @@ en:
       contributor_hint: 'The names and persistent identifiers of those hwo have contributed to the course material.'
       event_hint: 'Upcoming instances where this course will be taught or run.'
       structure_duration_hint: 'The time, in hours, it takes to complete the course, and the format this time will take.'
+      submission_notice: "After submitting this course, you will receive a confirmation email acknowledging that your course has been successfully submitted."
+      revision_notice: "After updating this course, an email will be sent to the administrators to notify them."
   events:
     hints:
       address: 'Where is this event being held?'
@@ -420,8 +422,8 @@ en:
       url: 'Enter a valid URL for the event landing page.'
       url_hint: "The link to your course website."
       venue_hint: "The room and building your course will take place in."
-
-
+      submission_notice: "After submitting this event, you will receive a confirmation email acknowledging that your event has been successfully submitted."
+      revision_notice: "After updating this event, an email will be sent to the administrators to notify them."
   materials:
     hints:
       authors: >


### PR DESCRIPTION
Ticket: https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/382 

Changes: Add conditional logic in view for displaying the relevant messages of relevant screen

---

<img width="3956" height="1568" alt="image" src="https://github.com/user-attachments/assets/7e2b8102-deb4-4b86-be1d-6e9d63e9e103" />

<img width="3956" height="1650" alt="image" src="https://github.com/user-attachments/assets/0fdd71a9-8696-40b8-abc5-e245a7e6f919" />

<img width="3956" height="1568" alt="image" src="https://github.com/user-attachments/assets/2b33b63e-779a-4867-9cca-f75ec8c5cb61" />

<img width="3956" height="1568" alt="image" src="https://github.com/user-attachments/assets/3fcec2f7-77fa-423e-b54b-4f4d85571adc" />
