### PR TITLE
Allow regular users to select events when creating/editing unapproved courses

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -65,12 +65,22 @@ class CoursesController < ApplicationController
             apply_direct_event_selection!(requested_event_ids)
           end
         rescue ActiveRecord::RecordInvalid => e
-          @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.') unless e.record.is_a?(Course)
+          rolled_back_errors = e.record.is_a?(Course) ? e.record.errors : nil
+
+          # If the transaction rolled back after a successful save!, @course can still appear persisted in-memory.
+          # Always rebuild for render to ensure the form posts to create (not update) and the object reflects the DB.
+          @course = Course.new(course_params.except(:event_ids))
+          @course.user = current_user if @course.respond_to?(:user=)
+
+          @course.errors.merge!(rolled_back_errors) if rolled_back_errors.present?
+          @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.') unless rolled_back_errors.present?
           set_selected_ids_for_form
           format.html { render :new }
           format.json { render json: @course.errors, status: :unprocessable_entity }
           next
         rescue ActiveRecord::RecordNotUnique
+          @course = Course.new(course_params.except(:event_ids))
+          @course.user = current_user if @course.respond_to?(:user=)
           @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.')
           set_selected_ids_for_form
           format.html { render :new }
@@ -131,67 +141,40 @@ class CoursesController < ApplicationController
     authorize @course
     normalize_authors_and_contributors
     normalize_node_ids
-    direct_event_linking = @course.approved?
+    requested_event_ids = event_ids_param_present? ? requested_event_ids_from_params : nil
+    update_params = course_params.except(:event_ids)
 
     respond_to do |format|
-      if direct_event_linking
-        requested_event_ids = event_ids_param_present? ? requested_event_ids_from_params : nil
-        update_params = course_params.except(:event_ids)
-
-        begin
-          ActiveRecord::Base.transaction do
-            @course.update!(update_params)
-            apply_direct_event_selection!(requested_event_ids) if requested_event_ids
-          end
-        rescue ActiveRecord::RecordInvalid => e
-          @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.') if requested_event_ids && !e.record.is_a?(Course)
-          set_selected_ids_for_form
-          format.html { render :edit }
-          format.json { render json: @course.errors, status: :unprocessable_entity }
-          next
-        rescue ActiveRecord::RecordNotUnique
-          @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.') if requested_event_ids
-          set_selected_ids_for_form
-          format.html { render :edit }
-          format.json { render json: @course.errors, status: :unprocessable_entity }
-          next
-        end
-
-        course_change_status_and_notify_admin
-        @course.create_activity(:update, owner: current_user) if @course.respond_to?(:create_activity)
-        format.html { redirect_to @course, notice: 'Course was successfully updated.' }
-        format.json { render :show, status: :ok, location: @course }
-        next
-      end
-
-      requested_event_ids = event_ids_param_present? ? requested_event_ids_from_params : nil
-      update_params = course_params.except(:event_ids)
-
-      if requested_event_ids
-        existing_linked_ids = @course.event_ids
-        existing_pending_ids = @course.course_pending_events.pluck(:event_id)
-
-        unless validate_unapproved_event_selection(
-          requested_event_ids,
-          existing_linked_ids: existing_linked_ids,
-          existing_pending_ids: existing_pending_ids
-        )
-          set_selected_ids_for_form
-          format.html { render :edit }
-          format.json { render json: @course.errors, status: :unprocessable_entity }
-          next
-        end
-      end
-
       begin
         ActiveRecord::Base.transaction do
-          @course.update!(update_params)
-          apply_unapproved_event_selection!(requested_event_ids) if requested_event_ids
+          @course.lock!
+
+          if @course.approved?
+            @course.update!(update_params)
+            apply_direct_event_selection!(requested_event_ids) if requested_event_ids
+
+            # Enforce invariant: approved courses should not retain pending claims.
+            @course.course_pending_events.delete_all
+          else
+            if requested_event_ids
+              existing_linked_ids = @course.event_ids
+              existing_pending_ids = @course.course_pending_events.pluck(:event_id)
+
+              unless validate_unapproved_event_selection(
+                requested_event_ids,
+                existing_linked_ids: existing_linked_ids,
+                existing_pending_ids: existing_pending_ids
+              )
+                raise ActiveRecord::RecordInvalid.new(@course)
+              end
+            end
+
+            @course.update!(update_params)
+            apply_unapproved_event_selection!(requested_event_ids) if requested_event_ids
+          end
         end
       rescue ActiveRecord::RecordInvalid => e
-        unless e.record.is_a?(Course)
-          @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.') if requested_event_ids
-        end
+        @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.') if requested_event_ids && !e.record.is_a?(Course)
         set_selected_ids_for_form
         format.html { render :edit }
         format.json { render json: @course.errors, status: :unprocessable_entity }

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -62,6 +62,7 @@ class CoursesController < ApplicationController
         format.html { redirect_to @course, notice: 'Course was successfully created.' }
         format.json { render :show, status: :created, location: @course }
       else
+        set_selected_ids_for_form
         format.html { render :new }
         format.json { render json: @course.errors, status: :unprocessable_entity }
       end
@@ -80,6 +81,7 @@ class CoursesController < ApplicationController
         format.html { redirect_to @course, notice: 'Course was successfully updated.' }
         format.json { render :show, status: :ok, location: @course }
       else
+        set_selected_ids_for_form
         format.html { render :edit }
         format.json { render json: @course.errors, status: :unprocessable_entity }
       end
@@ -157,6 +159,32 @@ class CoursesController < ApplicationController
     permitted.delete(:user_id) unless current_user&.is_admin?
 
     params.require(:course).permit(permitted)
+  end
+
+  def set_selected_ids_for_form
+    raw_params = params[:course]
+
+    content_providers_key_present =
+      raw_params.respond_to?(:key?) &&
+        (raw_params.key?(:content_provider_ids) || raw_params.key?('content_provider_ids'))
+
+    events_key_present =
+      raw_params.respond_to?(:key?) &&
+        (raw_params.key?(:event_ids) || raw_params.key?('event_ids'))
+
+    @selected_content_providers_id =
+      if content_providers_key_present
+        Array(raw_params[:content_provider_ids]).reject(&:blank?).map(&:to_i)
+      else
+        @course&.content_provider_ids || []
+      end
+
+    @selected_events_id =
+      if events_key_present
+        Array(raw_params[:event_ids]).reject(&:blank?).map(&:to_i)
+      else
+        @course&.event_ids || []
+      end
   end
 
   def course_check_exists_params

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -5,7 +5,6 @@ class CoursesController < ApplicationController
   before_action :set_course_dependencies, only: [:new, :edit, :create, :update]
   before_action :set_breadcrumbs
 
-  after_action :course_change_status_and_notify_admin, only: [:update]
   before_action only: [:show, :edit, :update] do
     authorize_resource_access(@course)
   end
@@ -45,7 +44,7 @@ class CoursesController < ApplicationController
   def edit
     authorize @course
     @selected_content_providers_id = @course.content_providers.pluck(:id)
-    @selected_events_id = @course.events.pluck(:id)
+    @selected_events_id = (@course.events.pluck(:id) + @course.course_pending_events.pluck(:event_id)).uniq
   end
 
   # POST /courses
@@ -53,19 +52,64 @@ class CoursesController < ApplicationController
     authorize Course
     normalize_authors_and_contributors
     normalize_node_ids
-    @course = Course.new(course_params)
+    requested_event_ids = requested_event_ids_from_params
+    direct_event_linking = current_user&.admin_or_trusted?
+    @course = Course.new(direct_event_linking ? course_params : course_params.except(:event_ids))
     @course.user = current_user if @course.respond_to?(:user=)
 
     respond_to do |format|
-      if @course.save
-        @course.create_activity :create, owner: current_user if @course.respond_to?(:create_activity)
-        format.html { redirect_to @course, notice: 'Course was successfully created.' }
-        format.json { render :show, status: :created, location: @course }
-      else
+      if direct_event_linking
+        if @course.save
+          @course.create_activity :create, owner: current_user if @course.respond_to?(:create_activity)
+          format.html { redirect_to @course, notice: 'Course was successfully created.' }
+          format.json { render :show, status: :created, location: @course }
+        else
+          set_selected_ids_for_form
+          format.html { render :new }
+          format.json { render json: @course.errors, status: :unprocessable_entity }
+        end
+        next
+      end
+
+      unless validate_unapproved_event_selection(
+        requested_event_ids,
+        existing_linked_ids: [],
+        existing_pending_ids: []
+      )
         set_selected_ids_for_form
         format.html { render :new }
         format.json { render json: @course.errors, status: :unprocessable_entity }
+        next
       end
+
+      begin
+        ActiveRecord::Base.transaction do
+          @course.save!
+          apply_unapproved_event_selection!(requested_event_ids)
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        if e.record.is_a?(CoursePendingEvent)
+          @course = Course.new(course_params.except(:event_ids))
+          @course.user = current_user if @course.respond_to?(:user=)
+          @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.')
+        end
+        set_selected_ids_for_form
+        format.html { render :new }
+        format.json { render json: @course.errors, status: :unprocessable_entity }
+        next
+      rescue ActiveRecord::RecordNotUnique
+        @course = Course.new(course_params.except(:event_ids))
+        @course.user = current_user if @course.respond_to?(:user=)
+        @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.')
+        set_selected_ids_for_form
+        format.html { render :new }
+        format.json { render json: @course.errors, status: :unprocessable_entity }
+        next
+      end
+
+      @course.create_activity :create, owner: current_user if @course.respond_to?(:create_activity)
+      format.html { redirect_to @course, notice: 'Course was successfully created.' }
+      format.json { render :show, status: :created, location: @course }
     end
   end
 
@@ -74,17 +118,67 @@ class CoursesController < ApplicationController
     authorize @course
     normalize_authors_and_contributors
     normalize_node_ids
+    direct_event_linking = @course.approved?
 
     respond_to do |format|
-      if @course.update(course_params)
-        @course.create_activity(:update, owner: current_user) if @course.respond_to?(:create_activity)
-        format.html { redirect_to @course, notice: 'Course was successfully updated.' }
-        format.json { render :show, status: :ok, location: @course }
-      else
+      if direct_event_linking
+        if @course.update(course_params)
+          course_change_status_and_notify_admin
+          @course.create_activity(:update, owner: current_user) if @course.respond_to?(:create_activity)
+          format.html { redirect_to @course, notice: 'Course was successfully updated.' }
+          format.json { render :show, status: :ok, location: @course }
+        else
+          set_selected_ids_for_form
+          format.html { render :edit }
+          format.json { render json: @course.errors, status: :unprocessable_entity }
+        end
+        next
+      end
+
+      requested_event_ids = event_ids_param_present? ? requested_event_ids_from_params : nil
+      update_params = course_params.except(:event_ids)
+
+      if requested_event_ids
+        existing_linked_ids = @course.event_ids
+        existing_pending_ids = @course.course_pending_events.pluck(:event_id)
+
+        unless validate_unapproved_event_selection(
+          requested_event_ids,
+          existing_linked_ids: existing_linked_ids,
+          existing_pending_ids: existing_pending_ids
+        )
+          set_selected_ids_for_form
+          format.html { render :edit }
+          format.json { render json: @course.errors, status: :unprocessable_entity }
+          next
+        end
+      end
+
+      begin
+        ActiveRecord::Base.transaction do
+          @course.update!(update_params)
+          apply_unapproved_event_selection!(requested_event_ids) if requested_event_ids
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        unless e.record.is_a?(Course)
+          @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.') if requested_event_ids
+        end
         set_selected_ids_for_form
         format.html { render :edit }
         format.json { render json: @course.errors, status: :unprocessable_entity }
+        next
+      rescue ActiveRecord::RecordNotUnique
+        @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.') if requested_event_ids
+        set_selected_ids_for_form
+        format.html { render :edit }
+        format.json { render json: @course.errors, status: :unprocessable_entity }
+        next
       end
+
+      course_change_status_and_notify_admin
+      @course.create_activity(:update, owner: current_user) if @course.respond_to?(:create_activity)
+      format.html { redirect_to @course, notice: 'Course was successfully updated.' }
+      format.json { render :show, status: :ok, location: @course }
     end
   end
 
@@ -183,7 +277,7 @@ class CoursesController < ApplicationController
       if events_key_present
         Array(raw_params[:event_ids]).reject(&:blank?).map(&:to_i)
       else
-        @course&.event_ids || []
+        (@course&.event_ids || []) + (@course&.course_pending_events&.pluck(:event_id) || [])
       end
   end
 
@@ -195,7 +289,8 @@ class CoursesController < ApplicationController
     @content_providers = ContentProvider.all
     approved_events = Event.where(event_status: Event.event_statuses[:approved])
     @events = if defined?(@course) && @course&.persisted?
-                approved_events.or(Event.where(id: @course.event_ids)).distinct.order(:title)
+                selected_event_ids = @course.event_ids + @course.course_pending_events.pluck(:event_id)
+                approved_events.or(Event.where(id: selected_event_ids)).distinct.order(:title)
               else
                 approved_events.order(:title)
               end
@@ -221,6 +316,8 @@ class CoursesController < ApplicationController
   end
 
   def normalize_node_ids
+    return unless params[:course].is_a?(ActionController::Parameters) || params[:course].is_a?(Hash)
+
     if params[:course][:node_ids].is_a?(String)
       params[:course][:node_ids] = [params[:course][:node_ids]]
     end
@@ -243,5 +340,72 @@ class CoursesController < ApplicationController
   # when the owner edits a course in "revisions_required" state.
   def course_change_status_and_notify_admin
     Notifications::CourseNotifier.new(@course).reset_status_and_notify_admin(current_user)
+  end
+
+  def event_ids_param_present?
+    raw_params = params[:course]
+    raw_params.respond_to?(:key?) &&
+      (raw_params.key?(:event_ids) || raw_params.key?('event_ids'))
+  end
+
+  def requested_event_ids_from_params
+    CourseEventLinkingEligibility.normalize_event_ids(params.dig(:course, :event_ids))
+  end
+
+  def validate_unapproved_event_selection(desired_event_ids, existing_linked_ids:, existing_pending_ids:)
+    to_add = desired_event_ids - existing_linked_ids - existing_pending_ids
+    to_unlink = existing_linked_ids - desired_event_ids
+
+    unauthorized_additions =
+      to_add - CourseEventLinkingEligibility.actor_manageable_event_ids(
+        actor: current_user,
+        request: request,
+        event_ids: to_add
+      )
+
+    unauthorized_unlinks =
+      to_unlink - CourseEventLinkingEligibility.actor_manageable_event_ids(
+        actor: current_user,
+        request: request,
+        event_ids: to_unlink
+      )
+
+    invalid = false
+    invalid ||= unauthorized_additions.any?
+    invalid ||= unauthorized_unlinks.any?
+    invalid ||= Event.where(id: to_add).where.not(event_status: Event.event_statuses[:approved]).exists?
+    invalid ||= Event.where(id: to_add).where.not(course_id: nil).exists?
+    invalid ||= CourseEventLinkingEligibility.pending_claim_conflict_event_ids(
+      event_ids: to_add,
+      course_id: @course&.id
+    ).any?
+
+    if invalid
+      @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.')
+      return false
+    end
+
+    true
+  end
+
+  def apply_unapproved_event_selection!(desired_event_ids)
+    desired_event_ids ||= []
+
+    existing_linked_ids = @course.event_ids
+    existing_pending_ids = @course.course_pending_events.pluck(:event_id)
+
+    to_add = desired_event_ids - existing_linked_ids - existing_pending_ids
+    to_unlink = existing_linked_ids - desired_event_ids
+    to_remove_pending = existing_pending_ids - desired_event_ids
+
+    Event.where(id: to_unlink, course_id: @course.id).find_each do |event|
+      event.update!(course_id: nil)
+    end
+
+    @course.course_pending_events.where(event_id: to_remove_pending).delete_all
+
+    to_add.each do |event_id|
+      @course.course_pending_events.create!(event_id: event_id)
+    end
   end
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -54,20 +54,33 @@ class CoursesController < ApplicationController
     normalize_node_ids
     requested_event_ids = requested_event_ids_from_params
     direct_event_linking = current_user&.admin_or_trusted?
-    @course = Course.new(direct_event_linking ? course_params : course_params.except(:event_ids))
+    @course = Course.new(course_params.except(:event_ids))
     @course.user = current_user if @course.respond_to?(:user=)
 
     respond_to do |format|
       if direct_event_linking
-        if @course.save
-          @course.create_activity :create, owner: current_user if @course.respond_to?(:create_activity)
-          format.html { redirect_to @course, notice: 'Course was successfully created.' }
-          format.json { render :show, status: :created, location: @course }
-        else
+        begin
+          ActiveRecord::Base.transaction do
+            @course.save!
+            apply_direct_event_selection!(requested_event_ids)
+          end
+        rescue ActiveRecord::RecordInvalid => e
+          @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.') unless e.record.is_a?(Course)
           set_selected_ids_for_form
           format.html { render :new }
           format.json { render json: @course.errors, status: :unprocessable_entity }
+          next
+        rescue ActiveRecord::RecordNotUnique
+          @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.')
+          set_selected_ids_for_form
+          format.html { render :new }
+          format.json { render json: @course.errors, status: :unprocessable_entity }
+          next
         end
+
+        @course.create_activity :create, owner: current_user if @course.respond_to?(:create_activity)
+        format.html { redirect_to @course, notice: 'Course was successfully created.' }
+        format.json { render :show, status: :created, location: @course }
         next
       end
 
@@ -122,16 +135,32 @@ class CoursesController < ApplicationController
 
     respond_to do |format|
       if direct_event_linking
-        if @course.update(course_params)
-          course_change_status_and_notify_admin
-          @course.create_activity(:update, owner: current_user) if @course.respond_to?(:create_activity)
-          format.html { redirect_to @course, notice: 'Course was successfully updated.' }
-          format.json { render :show, status: :ok, location: @course }
-        else
+        requested_event_ids = event_ids_param_present? ? requested_event_ids_from_params : nil
+        update_params = course_params.except(:event_ids)
+
+        begin
+          ActiveRecord::Base.transaction do
+            @course.update!(update_params)
+            apply_direct_event_selection!(requested_event_ids) if requested_event_ids
+          end
+        rescue ActiveRecord::RecordInvalid => e
+          @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.') if requested_event_ids && !e.record.is_a?(Course)
           set_selected_ids_for_form
           format.html { render :edit }
           format.json { render json: @course.errors, status: :unprocessable_entity }
+          next
+        rescue ActiveRecord::RecordNotUnique
+          @course.errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.') if requested_event_ids
+          set_selected_ids_for_form
+          format.html { render :edit }
+          format.json { render json: @course.errors, status: :unprocessable_entity }
+          next
         end
+
+        course_change_status_and_notify_admin
+        @course.create_activity(:update, owner: current_user) if @course.respond_to?(:create_activity)
+        format.html { redirect_to @course, notice: 'Course was successfully updated.' }
+        format.json { render :show, status: :ok, location: @course }
         next
       end
 
@@ -407,5 +436,39 @@ class CoursesController < ApplicationController
     to_add.each do |event_id|
       @course.course_pending_events.create!(event_id: event_id)
     end
+  end
+
+  def apply_direct_event_selection!(desired_event_ids)
+    desired_event_ids ||= []
+
+    locked_events =
+      Event.where(course_id: @course.id)
+           .or(Event.where(id: desired_event_ids))
+           .order(:id)
+           .lock('FOR UPDATE')
+           .to_a
+
+    existing_linked_ids = locked_events.select { |e| e.course_id == @course.id }.map(&:id)
+
+    unless validate_unapproved_event_selection(
+      desired_event_ids,
+      existing_linked_ids: existing_linked_ids,
+      existing_pending_ids: []
+    )
+      raise ActiveRecord::RecordInvalid.new(@course)
+    end
+
+    to_add = desired_event_ids - existing_linked_ids
+    to_unlink = existing_linked_ids - desired_event_ids
+
+    Event.where(id: to_unlink, course_id: @course.id).find_each do |event|
+      event.update!(course_id: nil)
+    end
+
+    Event.where(id: to_add, course_id: nil).find_each do |event|
+      event.update!(course_id: @course.id)
+    end
+
+    @course.course_pending_events.delete_all
   end
 end

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -32,7 +32,20 @@ module CoursesHelper
   end
 
   def course_event_option_label(event)
-    return event.title if event.blank?
+    return '' if event.blank?
+
+    course_user = respond_to?(:current_user) ? current_user : nil
+
+    # Avoid leaking metadata for events the current user cannot access.
+    # Events/courses use extra access rules (approved or owner/admin) in addition to Pundit policies.
+    showable_by_access_rules =
+      event.approved? ||
+        course_user&.is_admin? ||
+        (course_user && event.user_id == course_user.id && event.event_status != 'declined')
+
+    unless showable_by_access_rules && respond_to?(:policy) && policy(event).show?
+      return I18n.t('courses.event_option_restricted', default: 'Selected event (restricted)')
+    end
 
     status = event.respond_to?(:event_status) ? event.event_status : nil
     return event.title if status.blank? || status == 'approved'

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -10,6 +10,8 @@ class Course < ApplicationRecord
 
   has_and_belongs_to_many :content_providers
   has_many :events, dependent: :nullify
+  has_many :course_pending_events, dependent: :destroy
+  has_many :pending_events, through: :course_pending_events, source: :event
   belongs_to :user
 
   enum course_status: { awaiting_review: 0, approved: 1, declined: 2, revisions_required: 3}

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -60,6 +60,8 @@ class Course < ApplicationRecord
   clean_array_fields(:keywords, :target_audience)
 
   validate :cannot_unapprove_with_approved_events
+  validate :pending_events_linkable_on_approval, if: :course_status_transitioning_to_approved?
+  after_save :link_pending_events_on_approval, if: :course_status_just_approved_in_save?
 
 
   # Facet fields for search filters
@@ -155,5 +157,60 @@ class Course < ApplicationRecord
     return unless events.where(event_status: Event.event_statuses[:approved]).exists?
 
     errors.add(:course_status, :cannot_unapprove_with_approved_instances)
+  end
+
+  def course_status_transitioning_to_approved?
+    return false unless will_save_change_to_course_status?
+
+    old_status, new_status = course_status_change_to_be_saved
+    old_status.in?(%w[awaiting_review revisions_required]) && new_status == 'approved'
+  end
+
+  def course_status_just_approved_in_save?
+    return false unless saved_change_to_course_status?
+
+    old_status, new_status = saved_change_to_course_status
+    old_status.in?(%w[awaiting_review revisions_required]) && new_status == 'approved'
+  end
+
+  def pending_events_linkable_on_approval
+    @pending_events_to_link = nil
+
+    pending_event_ids = course_pending_events.order(:event_id).lock('FOR UPDATE').pluck(:event_id)
+    return if pending_event_ids.blank?
+
+    owner = user
+    invalid = owner.blank?
+
+    # Lock event rows in deterministic order for the remainder of this transaction.
+    locked_events = CourseEventLinkingEligibility.lock_events_for_update(pending_event_ids)
+    invalid ||= locked_events.map(&:id).sort != pending_event_ids.sort
+    invalid ||= locked_events.any? { |event| !event.approved? }
+    invalid ||= locked_events.any? { |event| event.course_id.present? && event.course_id != id }
+    invalid ||= locked_events.any? { |event| !CourseEventLinkingEligibility.owner_can_manage_event?(owner: owner, event: event) }
+
+    if invalid
+      errors.add(:events, 'One or more selected events are invalid, not permitted, or unavailable.')
+      return
+    end
+
+    # Pass locked events to the after_save callback via instance variable.
+    # This avoids re-querying and re-locking within the same transaction.
+    @pending_events_to_link = locked_events.select { |event| event.course_id != id }
+  end
+
+  def link_pending_events_on_approval
+    # Consumes @pending_events_to_link set by pending_events_linkable_on_approval validation.
+    return if @pending_events_to_link.nil?
+
+    @pending_events_to_link.each do |event|
+      next if event.course_id == id
+
+      event.update!(course_id: id)
+    end
+
+    course_pending_events.delete_all
+  ensure
+    @pending_events_to_link = nil
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -62,6 +62,7 @@ class Course < ApplicationRecord
   validate :cannot_unapprove_with_approved_events
   validate :pending_events_linkable_on_approval, if: :course_status_transitioning_to_approved?
   after_save :link_pending_events_on_approval, if: :course_status_just_approved_in_save?
+  after_save :clear_pending_events_on_decline, if: :course_status_just_declined_in_save?
 
 
   # Facet fields for search filters
@@ -173,6 +174,13 @@ class Course < ApplicationRecord
     old_status.in?(%w[awaiting_review revisions_required]) && new_status == 'approved'
   end
 
+  def course_status_just_declined_in_save?
+    return false unless saved_change_to_course_status?
+
+    _old_status, new_status = saved_change_to_course_status
+    new_status == 'declined'
+  end
+
   def pending_events_linkable_on_approval
     @pending_events_to_link = nil
 
@@ -212,5 +220,9 @@ class Course < ApplicationRecord
     course_pending_events.delete_all
   ensure
     @pending_events_to_link = nil
+  end
+
+  def clear_pending_events_on_decline
+    course_pending_events.delete_all
   end
 end

--- a/app/models/course_pending_event.rb
+++ b/app/models/course_pending_event.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CoursePendingEvent < ApplicationRecord
+  belongs_to :course
+  belongs_to :event
+
+  # DB unique index on event_id is the authoritative constraint; this validation provides user-facing errors.
+  validates :event_id, uniqueness: true
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -139,6 +139,7 @@ class Event < ApplicationRecord
 
   belongs_to :user
   belongs_to :course, optional: true
+  has_many :course_pending_events, dependent: :destroy
 
   has_one :llm_interaction, inverse_of: :event, dependent: :destroy
   accepts_nested_attributes_for :llm_interaction, allow_destroy: true

--- a/app/services/course_event_linking_eligibility.rb
+++ b/app/services/course_event_linking_eligibility.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class CourseEventLinkingEligibility
+  def self.normalize_event_ids(raw_ids)
+    Array(raw_ids).reject(&:blank?).map(&:to_i).reject(&:zero?).uniq
+  end
+
+  def self.actor_manageable_event_ids(actor:, request:, event_ids:)
+    return [] unless actor
+
+    context = Pundit::CurrentContext.new(actor, request)
+    manageable_event_ids_for_context(context: context, event_ids: event_ids)
+  end
+
+  # Approval-time check for whether the course owner is allowed to manage the event.
+  # This is request-agnostic by design (no scraper_user API exception).
+  def self.owner_can_manage_event?(owner:, event:)
+    return false unless owner && event
+
+    context = Pundit::CurrentContext.new(owner, nil)
+    EventPolicy.new(context, event).manage?
+  end
+
+  def self.owner_manageable_event_ids(owner:, event_ids:)
+    return [] unless owner
+
+    context = Pundit::CurrentContext.new(owner, nil)
+    manageable_event_ids_for_context(context: context, event_ids: event_ids)
+  end
+
+  def self.pending_claim_conflict_event_ids(event_ids:, course_id: nil)
+    requested_ids = normalize_event_ids(event_ids)
+    return [] if requested_ids.blank?
+
+    scope = CoursePendingEvent.where(event_id: requested_ids)
+    scope = scope.where.not(course_id: course_id) if course_id.present?
+    scope.distinct.order(:event_id).pluck(:event_id)
+  end
+
+  # Locks the event rows for update in deterministic ID order.
+  #
+  # NOTE: FOR UPDATE is only useful if the query is executed within an open transaction.
+  def self.lock_events_for_update(event_ids)
+    requested_ids = normalize_event_ids(event_ids)
+    return [] if requested_ids.blank?
+
+    Event.where(id: requested_ids).order(:id).lock('FOR UPDATE').to_a
+  end
+
+  def self.manageable_event_ids_for_context(context:, event_ids:)
+    return [] unless context.respond_to?(:user) && context.respond_to?(:request)
+
+    requested_ids = normalize_event_ids(event_ids)
+    return [] if requested_ids.blank?
+
+    events_by_id = Event.includes(:user, content_providers: :editors).where(id: requested_ids).index_by(&:id)
+
+    requested_ids.select do |id|
+      event = events_by_id[id]
+      next false unless event
+
+      EventPolicy.new(context, event).manage?
+    end
+  end
+  private_class_method :manageable_event_ids_for_context
+end

--- a/app/services/course_event_linking_eligibility.rb
+++ b/app/services/course_event_linking_eligibility.rb
@@ -8,7 +8,11 @@ class CourseEventLinkingEligibility
   def self.actor_manageable_event_ids(actor:, request:, event_ids:)
     return [] unless actor
 
-    context = Pundit::CurrentContext.new(actor, request)
+    # Disallow scraper_user API-only manage semantics for course-event selection.
+    # Treat scraper_user actor checks as request-agnostic so they only pass if the user can manage via non-API rules.
+    effective_request = actor.respond_to?(:has_role?) && actor.has_role?(:scraper_user) ? nil : request
+
+    context = Pundit::CurrentContext.new(actor, effective_request)
     manageable_event_ids_for_context(context: context, event_ids: event_ids)
   end
 

--- a/app/services/course_event_linking_eligibility.rb
+++ b/app/services/course_event_linking_eligibility.rb
@@ -44,7 +44,12 @@ class CourseEventLinkingEligibility
     requested_ids = normalize_event_ids(event_ids)
     return [] if requested_ids.blank?
 
-    Event.where(id: requested_ids).order(:id).lock('FOR UPDATE').to_a
+    # Preload associations used by policies to avoid N+1 queries while evaluating manage? checks.
+    Event.preload(:user, content_providers: [:user, :editors])
+         .where(id: requested_ids)
+         .order(:id)
+         .lock('FOR UPDATE')
+         .to_a
   end
 
   def self.manageable_event_ids_for_context(context:, event_ids:)
@@ -53,7 +58,7 @@ class CourseEventLinkingEligibility
     requested_ids = normalize_event_ids(event_ids)
     return [] if requested_ids.blank?
 
-    events_by_id = Event.includes(:user, content_providers: :editors).where(id: requested_ids).index_by(&:id)
+    events_by_id = Event.includes(:user, content_providers: [:user, :editors]).where(id: requested_ids).index_by(&:id)
 
     requested_ids.select do |id|
       event = events_by_id[id]

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -104,14 +104,14 @@
           title="<%= t('events.hints.content_provider_hint') %>">
     &#xe086;
   </span>
-    <%= f.collection_select :content_provider_ids, @content_providers, :id, :title,
-                            { include_blank: false },
-                            { class: "js-select2", style: "width: 100%;", multiple: true } do |content_provider| %>
-      <option value="<%= content_provider.id %>"
-              <%= 'selected="selected"' if @selected_content_providers_id.include?(content_provider.id) %>>
-        <%= content_provider.title %>
-      </option>
-    <% end %>
+	    <%= f.collection_select :content_provider_ids, @content_providers, :id, :title,
+	                            { include_blank: false },
+	                            { class: "js-select2", style: "width: 100%;", multiple: true } do |content_provider| %>
+        <option value="<%= content_provider.id %>"
+                <%= 'selected="selected"' if Array(@selected_content_providers_id).include?(content_provider.id) %>>
+          <%= content_provider.title %>
+        </option>
+      <% end %>
 
     <% if @course.errors[:content_providers].present? %>
     <span class="help-block small" style="color: #a02622;">

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -84,14 +84,14 @@
                  { include_blank: false },
                  { class: "js-select2", style: "width: 100%;", multiple: true } %>
 
-    <% if @course.errors[:events].present? %>
-    <span class="help-block small" style="color: #a02622;">
-      <%= @course.errors[:events].join(', ') %>
-    </span>
-    <% else %>
-      <span class="help-block small">Select any potential upcoming instances of your course</span>
-    <% end %>
-  </div>
+	    <% if @course.errors[:events].present? %>
+	    <span class="help-block small" style="color: #a02622;">
+	      <%= @course.errors[:events].join(', ') %>
+	    </span>
+	    <% else %>
+	      <span class="help-block small"><%= t('courses.hints.event_selection_help') %></span>
+	    <% end %>
+	  </div>
 
 
 

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -84,9 +84,9 @@
                  { include_blank: false },
                  { class: "js-select2", style: "width: 100%;", multiple: true } %>
 
-    <% if @course.errors[:content_providers].present? %>
+    <% if @course.errors[:events].present? %>
     <span class="help-block small" style="color: #a02622;">
-      <%= @course.errors[:content_providers].join(', ') %>
+      <%= @course.errors[:events].join(', ') %>
     </span>
     <% else %>
       <span class="help-block small">Select any potential upcoming instances of your course</span>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -41,6 +41,15 @@
         <% end %>
       </div>
 
+      <% if policy(@course).update? && !@course.approved? %>
+        <% pending_event_count = @course.course_pending_events.count %>
+        <% if pending_event_count.positive? %>
+          <div class="alert alert-info course-pending-events-notice">
+            <%= t('courses.messages.pending_event_selections_notice', count: pending_event_count) %>
+          </div>
+        <% end %>
+      <% end %>
+
       <%= render 'courses/partials/details_sections', course: @course %>
     </div>
 

--- a/app/views/public_activity/course/_update_parameter.html.erb
+++ b/app/views/public_activity/course/_update_parameter.html.erb
@@ -1,0 +1,4 @@
+<% unless activity.parameters.empty? %>
+    <%= render partial: 'public_activity/common/parameter_change', object: activity.parameters %>
+<% end %>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -547,8 +547,14 @@ en:
   courses:
     actions:
       create_instance: 'Create Course Instance'
+    hints:
+      event_selection_help: 'Select any potential upcoming instances of your course. If this course is awaiting approval, selections will be linked when the course is approved.'
     messages:
       not_approved_instance_help: 'This course is not approved yet. You can create course instances once the course is approved.'
+      pending_event_selections_notice:
+        one: 'This course has %{count} event selection pending. These will be linked automatically when the course is approved.'
+        other: 'This course has %{count} event selections pending. These will be linked automatically when the course is approved.'
+    event_option_restricted: 'Selected event (restricted)'
     event_option_status:
       awaiting_review: 'Pending review'
       declined: 'Declined'

--- a/db/migrate/20260216140047_create_course_pending_events.rb
+++ b/db/migrate/20260216140047_create_course_pending_events.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateCoursePendingEvents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :course_pending_events do |t|
+      t.references :course, null: false, foreign_key: { on_delete: :cascade }
+      # events.id is `serial` (integer), so the FK column must also be integer.
+      t.references :event, null: false, type: :integer, foreign_key: { on_delete: :cascade }, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_01_20_120551) do
+ActiveRecord::Schema[7.0].define(version: 2026_02_16_140047) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -172,6 +172,15 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_20_120551) do
     t.index ["content_provider_id", "user_id"], name: "provider_user_unique", unique: true
     t.index ["content_provider_id"], name: "index_content_providers_users_on_content_provider_id"
     t.index ["user_id"], name: "index_content_providers_users_on_user_id"
+  end
+
+  create_table "course_pending_events", force: :cascade do |t|
+    t.bigint "course_id", null: false
+    t.integer "event_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["course_id"], name: "index_course_pending_events_on_course_id"
+    t.index ["event_id"], name: "index_course_pending_events_on_event_id", unique: true
   end
 
   create_table "courses", force: :cascade do |t|
@@ -724,6 +733,8 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_20_120551) do
   add_foreign_key "collections", "users"
   add_foreign_key "content_providers", "nodes"
   add_foreign_key "content_providers", "users"
+  add_foreign_key "course_pending_events", "courses", on_delete: :cascade
+  add_foreign_key "course_pending_events", "events", on_delete: :cascade
   add_foreign_key "courses", "users"
   add_foreign_key "event_cities", "cities"
   add_foreign_key "event_cities", "events"

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -220,6 +220,185 @@ class CoursesControllerTest < ActionController::TestCase
     end
   end
 
+  test 'regular user create stores selected events as pending and does not link them' do
+    sign_in users(:regular_user)
+
+    approved_event = events(:one)
+    approved_event.update_column(:event_status, Event.event_statuses[:approved]) unless approved_event.approved?
+    assert_nil approved_event.course_id
+
+    parameters = @mandatory.merge(
+      node_ids: [@node.id],
+      content_provider_ids: [@content_providers.id],
+      event_ids: [approved_event.id]
+    )
+
+    assert_difference('Course.count', 1) do
+      assert_difference('CoursePendingEvent.count', 1) do
+        post :create, params: { course: parameters }
+      end
+    end
+
+    course = assigns(:course)
+    assert_redirected_to course_path(course)
+    assert_equal 'awaiting_review', course.course_status
+    assert_empty course.event_ids
+    assert CoursePendingEvent.exists?(course_id: course.id, event_id: approved_event.id)
+    assert_nil approved_event.reload.course_id
+  end
+
+  test 'regular user can update pending event selection on unapproved course' do
+    sign_in users(:regular_user)
+
+    first_event = events(:one)
+    second_event = events(:two)
+
+    parameters = @mandatory.merge(
+      node_ids: [@node.id],
+      content_provider_ids: [@content_providers.id],
+      event_ids: [first_event.id]
+    )
+    post :create, params: { course: parameters }
+    course = assigns(:course)
+
+    assert_equal [first_event.id], course.course_pending_events.pluck(:event_id).sort
+
+    patch :update, params: { id: course.id, course: { event_ids: [second_event.id] } }
+
+    assert_redirected_to course_path(course)
+    assert_equal [second_event.id], course.reload.course_pending_events.pluck(:event_id).sort
+    assert_empty course.event_ids
+    assert_nil first_event.reload.course_id
+    assert_nil second_event.reload.course_id
+  end
+
+  test 'regular user cannot select an event that is already pending for another course' do
+    sign_in users(:regular_user)
+
+    event = events(:one)
+    existing_course = Course.create!(
+      @mandatory.merge(
+        node_ids: [@node.id],
+        content_provider_ids: [@content_providers.id],
+        user: users(:regular_user)
+      )
+    )
+    CoursePendingEvent.create!(course: existing_course, event: event)
+
+    parameters = @mandatory.merge(
+      title: 'Another course',
+      node_ids: [@node.id],
+      content_provider_ids: [@content_providers.id],
+      event_ids: [event.id]
+    )
+
+    assert_no_difference('Course.count') do
+      post :create, params: { course: parameters }
+    end
+
+    assert_response :success
+    assert_template :new
+  end
+
+  test 'regular user cannot select an unapproved event' do
+    sign_in users(:regular_user)
+
+    unapproved_event = events(:one)
+    unapproved_event.update_column(:event_status, Event.event_statuses[:awaiting_review])
+    refute unapproved_event.approved?
+
+    parameters = @mandatory.merge(
+      title: 'Unapproved event selection course',
+      node_ids: [@node.id],
+      content_provider_ids: [@content_providers.id],
+      event_ids: [unapproved_event.id]
+    )
+
+    assert_no_difference('Course.count') do
+      post :create, params: { course: parameters }
+    end
+
+    assert_response :success
+    assert_template :new
+  end
+
+  test 'regular user cannot select an event already linked to another course' do
+    sign_in users(:regular_user)
+
+    linked_course = Course.create!(
+      @mandatory.merge(
+        title: 'Linked course',
+        node_ids: [@node.id],
+        content_provider_ids: [@content_providers.id],
+        user: users(:regular_user)
+      )
+    )
+    linked_course.update_column(:course_status, Course.course_statuses[:approved])
+
+    linked_event = events(:one)
+    linked_event.update!(course: linked_course)
+    assert_not_nil linked_event.course_id
+
+    parameters = @mandatory.merge(
+      title: 'Already linked event selection course',
+      node_ids: [@node.id],
+      content_provider_ids: [@content_providers.id],
+      event_ids: [linked_event.id]
+    )
+
+    assert_no_difference('Course.count') do
+      post :create, params: { course: parameters }
+    end
+
+    assert_response :success
+    assert_template :new
+  end
+
+  test 'regular user cannot select an event they do not manage' do
+    sign_in users(:regular_user)
+
+    template_event = events(:one)
+    other_users_provider = ContentProvider.create!(
+      title: 'Other users provider',
+      url: 'https://example.com/other-users-provider',
+      user: users(:another_regular_user)
+    )
+    other_users_event = Event.create!(
+      title: 'Other user event',
+      url: 'https://example.com/other-user-event',
+      user: users(:another_regular_user),
+      start: template_event.start,
+      end: template_event.end,
+      timezone: template_event.timezone,
+      contact: template_event.contact,
+      eligibility: template_event.eligibility,
+      host_institutions: template_event.host_institutions,
+      nodes: template_event.nodes,
+      language: template_event.language,
+      prerequisites: template_event.prerequisites,
+      target_audience: template_event.target_audience,
+      content_providers: [other_users_provider],
+      cost_basis: template_event.cost_basis,
+      learning_objectives: template_event.learning_objectives,
+      event_status: 'approved'
+    )
+    refute EventPolicy.new(Pundit::CurrentContext.new(users(:regular_user), nil), other_users_event).manage?
+
+    parameters = @mandatory.merge(
+      title: 'Unauthorized event selection course',
+      node_ids: [@node.id],
+      content_provider_ids: [@content_providers.id],
+      event_ids: [other_users_event.id]
+    )
+
+    assert_no_difference('Course.count') do
+      post :create, params: { course: parameters }
+    end
+
+    assert_response :success
+    assert_template :new
+  end
+
   test 'should create course for admin' do
     sign_in users(:admin)
     assert_difference('Course.count') do
@@ -292,6 +471,133 @@ class CoursesControllerTest < ActionController::TestCase
     assert_template :edit
     assert_select "select#course_content_provider_ids option[value='#{@content_providers.id}'][selected='selected']", count: 1
     assert_select "select#course_event_ids option[value='#{approved_event.id}'][selected='selected']", count: 1
+  end
+
+  test 'unapproved update without event_ids preserves pending claims and keeps selection visible on failure' do
+    sign_in users(:regular_user)
+
+    pending_event = events(:one)
+
+    post :create, params: { course: @mandatory.merge(
+      node_ids: [@node.id],
+      content_provider_ids: [@content_providers.id],
+      event_ids: [pending_event.id]
+    ) }
+    course = assigns(:course)
+    assert CoursePendingEvent.exists?(course_id: course.id, event_id: pending_event.id)
+
+    patch :update, params: { id: course.id, course: { title: '' } }
+
+    assert_response :success
+    assert_template :edit
+    assert CoursePendingEvent.exists?(course_id: course.id, event_id: pending_event.id)
+    assert_select "select#course_event_ids option[value='#{pending_event.id}'][selected='selected']", count: 1
+  end
+
+  test 'unapproved update without event_ids preserves pending claims on success' do
+    sign_in users(:regular_user)
+
+    pending_event = events(:one)
+
+    post :create, params: { course: @mandatory.merge(
+      node_ids: [@node.id],
+      content_provider_ids: [@content_providers.id],
+      event_ids: [pending_event.id]
+    ) }
+    course = assigns(:course)
+    assert CoursePendingEvent.exists?(course_id: course.id, event_id: pending_event.id)
+
+    patch :update, params: { id: course.id, course: { title: 'Updated title only' } }
+
+    assert_response :redirect
+    assert CoursePendingEvent.exists?(course_id: course.id, event_id: pending_event.id)
+    assert_nil pending_event.reload.course_id
+  end
+
+  test 'unapproved update with event_ids clears pending claims when empty selection submitted' do
+    sign_in users(:regular_user)
+
+    pending_event = events(:one)
+
+    post :create, params: { course: @mandatory.merge(
+      node_ids: [@node.id],
+      content_provider_ids: [@content_providers.id],
+      event_ids: [pending_event.id]
+    ) }
+    course = assigns(:course)
+    assert CoursePendingEvent.exists?(course_id: course.id, event_id: pending_event.id)
+
+    patch :update, params: { id: course.id, course: { event_ids: [''] } }
+
+    assert_response :redirect
+    assert_not CoursePendingEvent.exists?(course_id: course.id, event_id: pending_event.id)
+  end
+
+  test 'unapproved update hard-fails when trying to unlink a legacy linked event without permission' do
+    course = Course.create!(
+      @mandatory.merge(
+        title: 'Legacy linked event course',
+        node_ids: [@node.id],
+        content_provider_ids: [@content_providers.id],
+        user: users(:regular_user)
+      )
+    )
+
+    template_event = events(:one)
+    other_users_provider = ContentProvider.create!(
+      title: 'Legacy other users provider',
+      url: 'https://example.com/legacy-other-users-provider',
+      user: users(:another_regular_user)
+    )
+    legacy_event = Event.create!(
+      title: 'Legacy other user event',
+      url: 'https://example.com/legacy-other-user-event',
+      user: users(:another_regular_user),
+      start: template_event.start,
+      end: template_event.end,
+      timezone: template_event.timezone,
+      contact: template_event.contact,
+      eligibility: template_event.eligibility,
+      host_institutions: template_event.host_institutions,
+      nodes: template_event.nodes,
+      language: template_event.language,
+      prerequisites: template_event.prerequisites,
+      target_audience: template_event.target_audience,
+      content_providers: [other_users_provider],
+      cost_basis: template_event.cost_basis,
+      learning_objectives: template_event.learning_objectives,
+      event_status: 'approved'
+    )
+    refute EventPolicy.new(Pundit::CurrentContext.new(users(:regular_user), nil), legacy_event).manage?
+    legacy_event.update_column(:course_id, course.id)
+    assert_equal course.id, legacy_event.reload.course_id
+
+    sign_in users(:regular_user)
+    patch :update, params: { id: course.id, course: { event_ids: [''] } }
+
+    assert_response :success
+    assert_template :edit
+    assert_equal course.id, legacy_event.reload.course_id
+  end
+
+  test 'invalid update does not reset revisions_required status' do
+    course = Course.create!(
+      @mandatory.merge(
+        title: 'Revisions required course',
+        node_ids: [@node.id],
+        content_provider_ids: [@content_providers.id],
+        user: users(:regular_user)
+      )
+    )
+    course.update_column(:course_status, Course.course_statuses[:revisions_required])
+    assert_equal 'revisions_required', course.course_status
+
+    sign_in users(:regular_user)
+    patch :update, params: { id: course.id, course: { title: '' } }
+
+    assert_response :success
+    assert_template :edit
+    assert_equal 'revisions_required', course.reload.course_status
   end
 
   # SHOW TEST

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -235,6 +235,30 @@ class CoursesControllerTest < ActionController::TestCase
     assert_redirected_to course_path(assigns(:course))
   end
 
+  test 'invalid create re-renders new and preserves content provider selection' do
+    sign_in users(:admin)
+
+    assert_no_difference('Course.count') do
+      approved_event = events(:one)
+      approved_event.update_column(:event_status, Event.event_statuses[:approved]) unless approved_event.approved?
+
+      parameters = @mandatory.merge(
+        {
+          title: '',
+          node_ids: [@node.id],
+          content_provider_ids: [@content_providers.id],
+          event_ids: [approved_event.id]
+        }
+      )
+      post :create, params: { course: parameters }
+    end
+
+    assert_response :success
+    assert_template :new
+    assert_select "select#course_content_provider_ids option[value='#{@content_providers.id}'][selected='selected']", count: 1
+    assert_select "select#course_event_ids option[value='#{events(:one).id}'][selected='selected']", count: 1
+  end
+
   test 'should not create course for non-logged in user' do
     assert_no_difference('Course.count') do
       # Create event with all mandatory fields
@@ -247,6 +271,27 @@ class CoursesControllerTest < ActionController::TestCase
       post :create, params: { course: parameters }
     end
     assert_redirected_to new_user_session_path
+  end
+
+  test 'invalid update re-renders edit and preserves content provider selection' do
+    parameters = @mandatory.merge(
+      {
+        nodes: [@node],
+        content_providers: [@content_providers],
+        user: @user
+      }
+    )
+    course = Course.create!(parameters)
+
+    sign_in course.user
+    approved_event = events(:one)
+    approved_event.update_column(:event_status, Event.event_statuses[:approved]) unless approved_event.approved?
+    patch :update, params: { id: course.id, course: { title: '', event_ids: [approved_event.id] } }
+
+    assert_response :success
+    assert_template :edit
+    assert_select "select#course_content_provider_ids option[value='#{@content_providers.id}'][selected='selected']", count: 1
+    assert_select "select#course_event_ids option[value='#{approved_event.id}'][selected='selected']", count: 1
   end
 
   # SHOW TEST

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -128,7 +128,7 @@ class CoursesControllerTest < ActionController::TestCase
     get :new
     assert_response :success
     assert_select "label[for='course_event_ids']", text: 'Event(s)'
-    assert_select 'span.help-block.small', text: 'Select any potential upcoming instances of your course'
+    assert_select 'span.help-block.small', text: /Select any potential upcoming instances of your course/
   end
 
   test 'should get new page for logged in users only' do
@@ -809,6 +809,39 @@ class CoursesControllerTest < ActionController::TestCase
     assert_select '.help-block', text: I18n.t('courses.messages.not_approved_instance_help')
   end
 
+  test 'unapproved course show displays pending event selection notice to owner' do
+    sign_in users(:regular_user)
+
+    course = courses(:one)
+    pending_event = events(:one)
+    pending_event.update_column(:event_status, Event.event_statuses[:approved]) unless pending_event.approved?
+    CoursePendingEvent.create!(course: course, event: pending_event)
+
+    get :show, params: { id: course.id }
+
+    assert_response :success
+    assert_select '.course-pending-events-notice', text: I18n.t('courses.messages.pending_event_selections_notice', count: 1)
+  end
+
+  test 'unapproved course show does not display pending event selection notice when no pending selections exist' do
+    sign_in users(:regular_user)
+
+    course = courses(:one)
+    get :show, params: { id: course.id }
+
+    assert_response :success
+    assert_select '.course-pending-events-notice', count: 0
+  end
+
+  test 'non-owner cannot view unapproved course' do
+    course = courses(:one)
+    sign_in users(:another_regular_user2)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      get :show, params: { id: course.id }
+    end
+  end
+
   test 'approved course allows creating course instances' do
     sign_in users(:regular_user)
 
@@ -819,6 +852,7 @@ class CoursesControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_select 'a', text: I18n.t('courses.actions.create_instance'), count: 1
+    assert_select '.course-pending-events-notice', count: 0
   end
 
   test 'course edit shows existing unapproved events with status' do
@@ -857,6 +891,48 @@ class CoursesControllerTest < ActionController::TestCase
     assert_includes assigns(:events).map(&:id), pending_event.id
     awaiting_review_label = I18n.t('courses.event_option_status.awaiting_review')
     assert_select "#course_event_ids option[value='#{pending_event.id}']", text: /Pending course instance\s*\(#{Regexp.escape(awaiting_review_label)}\)/
+  end
+
+  test 'course edit does not leak restricted event metadata for selected but unviewable events' do
+    sign_in users(:regular_user)
+
+    course = courses(:one)
+    other_user = users(:another_regular_user2)
+
+    other_provider = ContentProvider.create!(
+      title: 'Other Provider',
+      url: 'https://example.com/restricted-provider',
+      user: other_user,
+      contact: 'other@example.com'
+    )
+
+    template_event = events(:one)
+    restricted_event = Event.create!(
+      title: 'Restricted pending event',
+      url: 'https://example.com/restricted-pending-event',
+      user: other_user,
+      start: template_event.start,
+      end: template_event.end,
+      timezone: template_event.timezone,
+      contact: template_event.contact,
+      eligibility: template_event.eligibility,
+      host_institutions: template_event.host_institutions,
+      nodes: template_event.nodes,
+      language: template_event.language,
+      prerequisites: template_event.prerequisites,
+      target_audience: template_event.target_audience,
+      content_providers: [other_provider],
+      cost_basis: template_event.cost_basis,
+      learning_objectives: template_event.learning_objectives,
+      event_status: 'awaiting_review'
+    )
+    CoursePendingEvent.create!(course: course, event: restricted_event)
+
+    get :edit, params: { id: course.id }
+
+    assert_response :success
+    assert_select "#course_event_ids option[value='#{restricted_event.id}']", text: I18n.t('courses.event_option_restricted'), count: 1
+    assert_select "#course_event_ids option", text: /Restricted pending event/, count: 0
   end
 
   test 'should show event as json' do

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -756,6 +756,28 @@ class CoursesControllerTest < ActionController::TestCase
     assert_empty course.reload.course_pending_events.pluck(:event_id)
   end
 
+  test 'approved update without event_ids clears stale pending claims on success' do
+    course = Course.create!(
+      @mandatory.merge(
+        title: 'Approved course clears stale pending claims',
+        node_ids: [@node.id],
+        content_provider_ids: [@content_providers.id],
+        user: users(:regular_user)
+      )
+    )
+    course.update_column(:course_status, Course.course_statuses[:approved])
+
+    pending_event = events(:one)
+    CoursePendingEvent.create!(course: course, event: pending_event)
+    assert CoursePendingEvent.exists?(course_id: course.id, event_id: pending_event.id)
+
+    sign_in course.user
+    patch :update, params: { id: course.id, course: { title: 'Updated title only' } }
+
+    assert_response :redirect
+    assert_not CoursePendingEvent.exists?(course_id: course.id, event_id: pending_event.id)
+  end
+
   test 'invalid update does not reset revisions_required status' do
     course = Course.create!(
       @mandatory.merge(

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -414,6 +414,64 @@ class CoursesControllerTest < ActionController::TestCase
     assert_redirected_to course_path(assigns(:course))
   end
 
+  test 'admin create with event_ids links events directly and creates no pending claims' do
+    sign_in users(:admin)
+
+    event = events(:one)
+    event.update_column(:event_status, Event.event_statuses[:approved]) unless event.approved?
+    event.update_column(:course_id, nil)
+
+    parameters = @mandatory.merge(
+      title: 'Admin create links event',
+      node_ids: [@node.id],
+      content_provider_ids: [@content_providers.id],
+      event_ids: [event.id]
+    )
+
+    assert_difference('Course.count', 1) do
+      assert_no_difference('CoursePendingEvent.count') do
+        post :create, params: { course: parameters }
+      end
+    end
+
+    course = assigns(:course)
+    assert_redirected_to course_path(course)
+    assert_equal 'approved', course.course_status
+    assert_includes course.event_ids, event.id
+    assert_equal course.id, event.reload.course_id
+    assert_not CoursePendingEvent.exists?(course_id: course.id, event_id: event.id)
+  end
+
+  test 'admin create hard-fails when selected event is already pending for another course' do
+    sign_in users(:admin)
+
+    event = events(:one)
+    event.update_column(:event_status, Event.event_statuses[:approved]) unless event.approved?
+
+    existing_course = Course.create!(
+      @mandatory.merge(
+        node_ids: [@node.id],
+        content_provider_ids: [@content_providers.id],
+        user: users(:regular_user)
+      )
+    )
+    CoursePendingEvent.create!(course: existing_course, event: event)
+
+    parameters = @mandatory.merge(
+      title: 'Admin conflicting course',
+      node_ids: [@node.id],
+      content_provider_ids: [@content_providers.id],
+      event_ids: [event.id]
+    )
+
+    assert_no_difference('Course.count') do
+      post :create, params: { course: parameters }
+    end
+
+    assert_response :success
+    assert_template :new
+  end
+
   test 'invalid create re-renders new and preserves content provider selection' do
     sign_in users(:admin)
 
@@ -578,6 +636,124 @@ class CoursesControllerTest < ActionController::TestCase
     assert_response :success
     assert_template :edit
     assert_equal course.id, legacy_event.reload.course_id
+  end
+
+  test 'approved update hard-fails when trying to add an event pending for another course' do
+    course = Course.create!(
+      @mandatory.merge(
+        title: 'Approved course',
+        node_ids: [@node.id],
+        content_provider_ids: [@content_providers.id],
+        user: users(:regular_user)
+      )
+    )
+    course.update_column(:course_status, Course.course_statuses[:approved])
+    assert_equal 'approved', course.course_status
+
+    pending_event = events(:one)
+    pending_event.update_column(:event_status, Event.event_statuses[:approved]) unless pending_event.approved?
+    pending_event.update_column(:user_id, course.user.id) unless pending_event.user_id == course.user.id
+    assert_nil pending_event.course_id
+
+    other_course = Course.create!(
+      @mandatory.merge(
+        title: 'Other course with pending event',
+        node_ids: [@node.id],
+        content_provider_ids: [@content_providers.id],
+        user: users(:regular_user)
+      )
+    )
+    CoursePendingEvent.create!(course: other_course, event: pending_event)
+
+    sign_in course.user
+    patch :update, params: { id: course.id, course: { event_ids: [pending_event.id] } }
+
+    assert_response :success
+    assert_template :edit
+    assert_empty course.reload.event_ids
+    assert_nil pending_event.reload.course_id
+  end
+
+  test 'approved update hard-fails when trying to unlink an event without permission' do
+    course = Course.create!(
+      @mandatory.merge(
+        title: 'Approved course with legacy linked event',
+        node_ids: [@node.id],
+        content_provider_ids: [@content_providers.id],
+        user: users(:regular_user)
+      )
+    )
+    course.update_column(:course_status, Course.course_statuses[:approved])
+    assert_equal 'approved', course.course_status
+
+    template_event = events(:one)
+    other_users_provider = ContentProvider.create!(
+      title: 'Approved legacy other users provider',
+      url: 'https://example.com/approved-legacy-other-users-provider',
+      user: users(:another_regular_user)
+    )
+    legacy_event = Event.create!(
+      title: 'Approved legacy other user event',
+      url: 'https://example.com/approved-legacy-other-user-event',
+      user: users(:another_regular_user),
+      start: template_event.start,
+      end: template_event.end,
+      timezone: template_event.timezone,
+      contact: template_event.contact,
+      eligibility: template_event.eligibility,
+      host_institutions: template_event.host_institutions,
+      nodes: template_event.nodes,
+      language: template_event.language,
+      prerequisites: template_event.prerequisites,
+      target_audience: template_event.target_audience,
+      content_providers: [other_users_provider],
+      cost_basis: template_event.cost_basis,
+      learning_objectives: template_event.learning_objectives,
+      event_status: 'approved'
+    )
+    refute EventPolicy.new(Pundit::CurrentContext.new(users(:regular_user), nil), legacy_event).manage?
+    legacy_event.update_column(:course_id, course.id)
+    assert_equal course.id, legacy_event.reload.course_id
+
+    sign_in course.user
+    patch :update, params: { id: course.id, course: { event_ids: [''] } }
+
+    assert_response :success
+    assert_template :edit
+    assert_equal course.id, legacy_event.reload.course_id
+  end
+
+  test 'approved update can link and unlink events and clears pending claims on success' do
+    course = Course.create!(
+      @mandatory.merge(
+        title: 'Approved course direct update success',
+        node_ids: [@node.id],
+        content_provider_ids: [@content_providers.id],
+        user: users(:regular_user)
+      )
+    )
+    course.update_column(:course_status, Course.course_statuses[:approved])
+    assert_equal 'approved', course.course_status
+
+    first_event = events(:one)
+    second_event = events(:two)
+    [first_event, second_event].each do |event|
+      event.update_column(:event_status, Event.event_statuses[:approved]) unless event.approved?
+      event.update_column(:course_id, nil)
+      event.update_column(:user_id, course.user.id) unless event.user_id == course.user.id
+    end
+
+    first_event.update!(course: course)
+    CoursePendingEvent.create!(course: course, event: second_event)
+    assert CoursePendingEvent.exists?(course_id: course.id, event_id: second_event.id)
+
+    sign_in course.user
+    patch :update, params: { id: course.id, course: { event_ids: [second_event.id] } }
+
+    assert_response :redirect
+    assert_nil first_event.reload.course_id
+    assert_equal course.id, second_event.reload.course_id
+    assert_empty course.reload.course_pending_events.pluck(:event_id)
   end
 
   test 'invalid update does not reset revisions_required status' do

--- a/test/fixtures/course_pending_events.yml
+++ b/test/fixtures/course_pending_events.yml
@@ -1,0 +1,2 @@
+# Intentionally empty. Pending claim rows are created dynamically in tests.
+{}

--- a/test/integration/courses/workflow/admin_approval_flow_test.rb
+++ b/test/integration/courses/workflow/admin_approval_flow_test.rb
@@ -252,7 +252,23 @@ class AdminApprovalFlowCourseTest < ActionDispatch::IntegrationTest
   test "admin rejects course" do
     sign_in @admin
 
+    pending_event = create_event_from_template(
+      title: 'Pending event released on decline',
+      url: 'https://example.com/pending-event-released-on-decline',
+      user: @user
+    )
+    CoursePendingEvent.create!(course: @pending_course, event: pending_event)
+    assert CoursePendingEvent.exists?(course_id: @pending_course.id, event_id: pending_event.id)
+
     @pending_course.update!(course_status: Course.course_statuses[:declined])
+    assert_not CoursePendingEvent.exists?(course_id: @pending_course.id, event_id: pending_event.id)
+
+    other_course = @user.courses.create!(@parameters.merge(
+      title: 'Other course can re-claim declined pending event',
+      url: 'https://example.com/other-course-can-re-claim-declined-pending-event'
+    ))
+    CoursePendingEvent.create!(course: other_course, event: pending_event)
+    assert CoursePendingEvent.exists?(course_id: other_course.id, event_id: pending_event.id)
 
     # Admin can see
     get "/courses/#{@pending_course.id}", params: { format: :json }

--- a/test/integration/courses/workflow/admin_approval_flow_test.rb
+++ b/test/integration/courses/workflow/admin_approval_flow_test.rb
@@ -60,6 +60,13 @@ class AdminApprovalFlowCourseTest < ActionDispatch::IntegrationTest
   test "admin approves pending course" do
     sign_in @admin
 
+    pending_event = create_event_from_template(
+      title: 'Pending approval event',
+      url: 'https://example.com/pending-approval-event',
+      user: @user
+    )
+    CoursePendingEvent.create!(course: @pending_course, event: pending_event)
+
     perform_enqueued_jobs do
       # Simulate approving course
       assert_emails 2 do
@@ -78,8 +85,167 @@ class AdminApprovalFlowCourseTest < ActionDispatch::IntegrationTest
 
     # Course should be approved
     assert_equal "approved", @pending_course.reload.course_status
+    assert_equal @pending_course.id, pending_event.reload.course_id
+    assert_empty @pending_course.course_pending_events.pluck(:event_id)
 
     sign_out @admin
+  end
+
+  test "admin cannot approve pending course when pending events are no longer linkable" do
+    sign_in @admin
+
+    pending_event = create_event_from_template(
+      title: 'Conflicting pending event',
+      url: 'https://example.com/conflicting-pending-event',
+      user: @user
+    )
+    CoursePendingEvent.create!(course: @pending_course, event: pending_event)
+
+    other_course = @user.courses.create!(@parameters.merge(
+      title: 'Other approved course',
+      url: 'https://example.com/other-approved-course'
+    ))
+    other_course.update_column(:course_status, Course.course_statuses[:approved])
+    pending_event.update_column(:course_id, other_course.id)
+
+    clear_enqueued_jobs
+    clear_performed_jobs
+    approved_events_count_before = @user.reload.approved_events_count
+
+    assert_no_enqueued_jobs do
+      assert_raises(ActiveRecord::RecordInvalid) do
+        @pending_course.update!(course_status: Course.course_statuses[:approved])
+      end
+    end
+
+    assert_equal "awaiting_review", @pending_course.reload.course_status
+    assert_equal other_course.id, pending_event.reload.course_id
+    assert CoursePendingEvent.exists?(course_id: @pending_course.id, event_id: pending_event.id)
+    assert_equal approved_events_count_before, @user.reload.approved_events_count
+  end
+
+  test "admin cannot approve pending course when pending events are no longer approved" do
+    sign_in @admin
+
+    pending_event = create_event_from_template(
+      title: 'Pending event that becomes unapproved',
+      url: 'https://example.com/pending-event-that-becomes-unapproved',
+      user: @user
+    )
+    CoursePendingEvent.create!(course: @pending_course, event: pending_event)
+    pending_event.update_column(:event_status, Event.event_statuses[:awaiting_review])
+
+    clear_enqueued_jobs
+    clear_performed_jobs
+    approved_events_count_before = @user.reload.approved_events_count
+
+    assert_no_enqueued_jobs do
+      assert_raises(ActiveRecord::RecordInvalid) do
+        @pending_course.update!(course_status: Course.course_statuses[:approved])
+      end
+    end
+
+    assert_equal "awaiting_review", @pending_course.reload.course_status
+    assert_nil pending_event.reload.course_id
+    assert CoursePendingEvent.exists?(course_id: @pending_course.id, event_id: pending_event.id)
+    assert_equal approved_events_count_before, @user.reload.approved_events_count
+  end
+
+  test "admin cannot approve pending course when owner cannot manage pending events" do
+    sign_in @admin
+
+    other_provider = ContentProvider.create!(
+      title: 'Other Provider',
+      url: 'https://example.com/other-provider',
+      user: @user2,
+      contact: 'other@example.com'
+    )
+
+    pending_event = create_event_from_template(
+      title: 'Restricted pending event',
+      url: 'https://example.com/restricted-pending-event',
+      user: @user2,
+      content_providers: [other_provider]
+    )
+    CoursePendingEvent.create!(course: @pending_course, event: pending_event)
+
+    clear_enqueued_jobs
+    clear_performed_jobs
+    approved_events_count_before = @user.reload.approved_events_count
+
+    assert_no_enqueued_jobs do
+      assert_raises(ActiveRecord::RecordInvalid) do
+        @pending_course.update!(course_status: Course.course_statuses[:approved])
+      end
+    end
+
+    assert_equal "awaiting_review", @pending_course.reload.course_status
+    assert_nil pending_event.reload.course_id
+    assert CoursePendingEvent.exists?(course_id: @pending_course.id, event_id: pending_event.id)
+    assert_equal approved_events_count_before, @user.reload.approved_events_count
+  end
+
+  test "admin cannot approve pending course when one of multiple pending events becomes invalid" do
+    sign_in @admin
+
+    ok_event = create_event_from_template(
+      title: 'Pending ok event',
+      url: 'https://example.com/pending-ok-event',
+      user: @user
+    )
+    conflicting_event = create_event_from_template(
+      title: 'Pending conflicting event',
+      url: 'https://example.com/pending-conflicting-event',
+      user: @user
+    )
+    CoursePendingEvent.create!(course: @pending_course, event: ok_event)
+    CoursePendingEvent.create!(course: @pending_course, event: conflicting_event)
+
+    other_course = @user.courses.create!(@parameters.merge(
+      title: 'Other approved course',
+      url: 'https://example.com/other-approved-course-2'
+    ))
+    other_course.update_column(:course_status, Course.course_statuses[:approved])
+    conflicting_event.update_column(:course_id, other_course.id)
+
+    clear_enqueued_jobs
+    clear_performed_jobs
+    approved_events_count_before = @user.reload.approved_events_count
+
+    assert_no_enqueued_jobs do
+      assert_raises(ActiveRecord::RecordInvalid) do
+        @pending_course.update!(course_status: Course.course_statuses[:approved])
+      end
+    end
+
+    assert_equal "awaiting_review", @pending_course.reload.course_status
+    assert_nil ok_event.reload.course_id
+    assert_equal other_course.id, conflicting_event.reload.course_id
+    assert CoursePendingEvent.exists?(course_id: @pending_course.id, event_id: ok_event.id)
+    assert CoursePendingEvent.exists?(course_id: @pending_course.id, event_id: conflicting_event.id)
+    assert_equal approved_events_count_before, @user.reload.approved_events_count
+  end
+
+  test "admin approves pending course clears pending claims when pending event is already linked" do
+    sign_in @admin
+
+    pending_event = create_event_from_template(
+      title: 'Already linked pending event',
+      url: 'https://example.com/already-linked-pending-event',
+      user: @user
+    )
+    CoursePendingEvent.create!(course: @pending_course, event: pending_event)
+    pending_event.update_column(:course_id, @pending_course.id)
+
+    perform_enqueued_jobs do
+      assert_emails 2 do
+        @pending_course.update!(course_status: Course.course_statuses[:approved])
+      end
+    end
+
+    assert_equal "approved", @pending_course.reload.course_status
+    assert_equal @pending_course.id, pending_event.reload.course_id
+    assert_empty @pending_course.course_pending_events.pluck(:event_id)
   end
 
   # Reject course
@@ -133,5 +299,30 @@ class AdminApprovalFlowCourseTest < ActionDispatch::IntegrationTest
     assert_raises(ActiveRecord::RecordNotFound) do
       get "/courses/#{@pending_course.id}", params: { format: :json }
     end
+  end
+
+  private
+
+  def create_event_from_template(title:, url:, user:, content_providers: [@content_provider], event_status: 'approved')
+    template_event = events(:one)
+    Event.create!(
+      title: title,
+      url: url,
+      user: user,
+      start: template_event.start,
+      end: template_event.end,
+      timezone: template_event.timezone,
+      contact: template_event.contact,
+      eligibility: template_event.eligibility,
+      host_institutions: template_event.host_institutions,
+      nodes: template_event.nodes,
+      language: template_event.language,
+      prerequisites: template_event.prerequisites,
+      target_audience: template_event.target_audience,
+      content_providers: content_providers,
+      cost_basis: template_event.cost_basis,
+      learning_objectives: template_event.learning_objectives,
+      event_status: event_status
+    )
   end
 end

--- a/test/models/course_pending_event_test.rb
+++ b/test/models/course_pending_event_test.rb
@@ -22,7 +22,7 @@ class CoursePendingEventTest < ActiveSupport::TestCase
     assert_includes dup.errors[:event_id], "has already been taken"
 
     assert_raises(ActiveRecord::RecordNotUnique, ActiveRecord::StatementInvalid) do
-      CoursePendingEvent.insert_all(
+      CoursePendingEvent.insert_all!(
         [
           {
             course_id: courses(:two).id,
@@ -46,8 +46,9 @@ class CoursePendingEventTest < ActiveSupport::TestCase
     end
   end
 
-  test "event delete cascades pending event rows" do
+  test "event destroy removes pending event rows" do
     course = courses(:one)
+    provider = content_providers(:goblet)
 
     event = Event.create!(
       title: "Pending event cleanup test",
@@ -71,6 +72,7 @@ class CoursePendingEventTest < ActiveSupport::TestCase
       target_audience: ["Everyone"],
       cost_basis: "Free",
       registration_form_url: "https://example.com/registration",
+      content_providers: [provider],
       nodes: [nodes(:westeros)]
     )
 
@@ -78,8 +80,7 @@ class CoursePendingEventTest < ActiveSupport::TestCase
     assert_equal 1, CoursePendingEvent.where(event_id: event.id).count
 
     assert_difference("CoursePendingEvent.count", -1) do
-      event.delete
+      event.destroy
     end
   end
 end
-

--- a/test/models/course_pending_event_test.rb
+++ b/test/models/course_pending_event_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CoursePendingEventTest < ActiveSupport::TestCase
+  test "is valid with a course and an event" do
+    cpe = CoursePendingEvent.new(course: courses(:one), event: events(:one))
+
+    assert cpe.valid?
+  end
+
+  test "requires course and event" do
+    assert_not CoursePendingEvent.new(event: events(:one)).valid?
+    assert_not CoursePendingEvent.new(course: courses(:one)).valid?
+  end
+
+  test "enforces event exclusivity (validation + DB constraint)" do
+    CoursePendingEvent.create!(course: courses(:one), event: events(:one))
+
+    dup = CoursePendingEvent.new(course: courses(:two), event: events(:one))
+    assert_not dup.valid?
+    assert_includes dup.errors[:event_id], "has already been taken"
+
+    assert_raises(ActiveRecord::RecordNotUnique, ActiveRecord::StatementInvalid) do
+      CoursePendingEvent.insert_all(
+        [
+          {
+            course_id: courses(:two).id,
+            event_id: events(:one).id,
+            created_at: Time.current,
+            updated_at: Time.current
+          }
+        ]
+      )
+    end
+  end
+
+  test "course destroy removes pending event rows" do
+    course = courses(:one)
+    event = events(:one)
+
+    CoursePendingEvent.create!(course: course, event: event)
+
+    assert_difference("CoursePendingEvent.count", -1) do
+      course.destroy
+    end
+  end
+
+  test "event delete cascades pending event rows" do
+    course = courses(:one)
+
+    event = Event.create!(
+      title: "Pending event cleanup test",
+      url: "https://example.com/pending-event-cleanup-test",
+      description: "Test event",
+      event_types: ["workshops_and_courses"],
+      start: Time.zone.parse("2030-01-01 10:00:00"),
+      end: Time.zone.parse("2030-01-01 12:00:00"),
+      sponsors: [],
+      keywords: [],
+      user: users(:regular_user),
+      host_institutions: [],
+      contact: "Test contact",
+      eligibility: ["first_come_first_served"],
+      timezone: "UTC",
+      duration: "00:00",
+      learning_objectives: "None",
+      recognition: "None",
+      language: "en",
+      prerequisites: "None",
+      target_audience: ["Everyone"],
+      cost_basis: "Free",
+      registration_form_url: "https://example.com/registration",
+      nodes: [nodes(:westeros)]
+    )
+
+    CoursePendingEvent.create!(course: course, event: event)
+    assert_equal 1, CoursePendingEvent.where(event_id: event.id).count
+
+    assert_difference("CoursePendingEvent.count", -1) do
+      event.delete
+    end
+  end
+end
+

--- a/test/models/material_test.rb
+++ b/test/models/material_test.rb
@@ -400,17 +400,16 @@ class MaterialTest < ActiveSupport::TestCase
                                             { title: 'Cooler Website!', url: 'https://tess.elixir-europe.org/' }])
     end
 
-    er = material.reload.external_resources
-    assert_equal 2, er.count
-    assert_equal 'Cool Website!', er[0].title
-    assert_equal 'https://tess.elixir-uk.org/', er[0].url
-    assert_equal 'Cooler Website!', er[1].title
-    assert_equal 'https://tess.elixir-europe.org/', er[1].url
+    er_by_url = material.reload.external_resources.index_by(&:url)
+    assert_equal 2, er_by_url.count
+    assert_equal 'Cool Website!', er_by_url.fetch('https://tess.elixir-uk.org/').title
+    assert_equal 'Cooler Website!', er_by_url.fetch('https://tess.elixir-europe.org/').title
   end
 
   test 'should remove redundant external resources and preserve IDs of retained ones' do
     material = materials(:material_with_external_resource)
     original_resources = material.external_resources.to_a
+    original_by_url = original_resources.index_by(&:url)
     assert_equal 3, original_resources.length
 
     # [
@@ -424,37 +423,47 @@ class MaterialTest < ActiveSupport::TestCase
                                             { title: 'Changed title', url: 'https://bio.tools/tool/SR-Tesseler' }])
     end
 
-    er = material.reload.external_resources
-    assert_equal 2, er.count
-    assert_equal 'TeSS', er[0].title
-    assert_equal 'https://tess.elixir-uk.org/', er[0].url
-    assert_equal original_resources[0].id, er[0].id, 'Should have preserved original ExternalResource'
-    assert_equal 'Changed title', er[1].title
-    assert_equal 'https://bio.tools/tool/SR-Tesseler', er[1].url
-    assert_not_equal original_resources[1].id, er[1].id, 'Should have replaced modified ExternalResource'
+    er_by_url = material.reload.external_resources.index_by(&:url)
+    assert_equal 2, er_by_url.count
+
+    tess = er_by_url.fetch('https://tess.elixir-uk.org/')
+    assert_equal 'TeSS', tess.title
+    assert_equal original_by_url.fetch('https://tess.elixir-uk.org/').id, tess.id, 'Should have preserved original ExternalResource'
+
+    changed = er_by_url.fetch('https://bio.tools/tool/SR-Tesseler')
+    assert_equal 'Changed title', changed.title
+    assert_not_equal original_by_url.fetch('https://bio.tools/tool/SR-Tesseler').id, changed.id, 'Should have replaced modified ExternalResource'
   end
 
   test 'can set external resources using objects or params' do
     material = materials(:material_with_external_resource)
     original_resources = material.external_resources.to_a
+    original_by_url = original_resources.index_by(&:url)
     assert_equal 3, original_resources.length
 
     assert_no_difference('ExternalResource.count') do
-      material.update!(external_resources: original_resources.first(2) +
-        [{ title: 'Zombocom', url: 'https://zombo.com' }])
+      material.update!(external_resources: [
+        original_by_url.fetch('https://tess.elixir-uk.org/'),
+        original_by_url.fetch('https://bio.tools/tool/SR-Tesseler'),
+        { title: 'Zombocom', url: 'https://zombo.com' }
+      ])
     end
 
-    er = material.reload.external_resources
-    assert_equal 3, er.count
-    assert_equal 'TeSS', er[0].title
-    assert_equal 'https://tess.elixir-uk.org/', er[0].url
-    assert_equal original_resources[0].id, er[0].id, 'Should have preserved first ExternalResource'
-    assert_equal 'SR-Tesseler', er[1].title
-    assert_equal 'https://bio.tools/tool/SR-Tesseler', er[1].url
-    assert_equal original_resources[1].id, er[1].id, 'Should have preserved second ExternalResource'
-    assert_equal 'Zombocom', er[2].title
-    assert_equal 'https://zombo.com', er[2].url
-    assert_not_equal original_resources[2].id, er[2].id, 'Should have replaced third ExternalResource'
+    er_by_url = material.reload.external_resources.index_by(&:url)
+    assert_equal 3, er_by_url.count
+
+    tess = er_by_url.fetch('https://tess.elixir-uk.org/')
+    assert_equal 'TeSS', tess.title
+    assert_equal original_by_url.fetch('https://tess.elixir-uk.org/').id, tess.id, 'Should have preserved first ExternalResource'
+
+    sr = er_by_url.fetch('https://bio.tools/tool/SR-Tesseler')
+    assert_equal 'SR-Tesseler', sr.title
+    assert_equal original_by_url.fetch('https://bio.tools/tool/SR-Tesseler').id, sr.id, 'Should have preserved second ExternalResource'
+
+    zombocom = er_by_url.fetch('https://zombo.com')
+    assert_equal 'Zombocom', zombocom.title
+    assert_not_equal original_by_url.fetch('https://fairsharing.org/bsg-p123456').id, zombocom.id,
+                     'Should have replaced third ExternalResource'
   end
 
   test 'verified users scope' do

--- a/test/unit/course_event_linking_eligibility_test.rb
+++ b/test/unit/course_event_linking_eligibility_test.rb
@@ -13,16 +13,14 @@ class CourseEventLinkingEligibilityTest < ActiveSupport::TestCase
     assert_equal [event.id], CourseEventLinkingEligibility.actor_manageable_event_ids(actor: users(:curator), request: nil, event_ids: [event.id])
   end
 
-  test 'actor_manageable_event_ids respects request-sensitive scraper_user permissions' do
+  test 'actor_manageable_event_ids does not grant scraper_user api-only permissions for course linking' do
     event = events(:one)
     scraper = users(:scraper_user)
 
     api_format = Struct.new(:json?).new(true)
     api_request = Struct.new(:post?, :put?, :patch?, :format).new(true, false, false, api_format)
-    non_api_request = Struct.new(:post?, :put?, :patch?, :format).new(false, false, false, api_format)
 
-    assert_equal [event.id], CourseEventLinkingEligibility.actor_manageable_event_ids(actor: scraper, request: api_request, event_ids: [event.id])
-    assert_equal [], CourseEventLinkingEligibility.actor_manageable_event_ids(actor: scraper, request: non_api_request, event_ids: [event.id])
+    assert_equal [], CourseEventLinkingEligibility.actor_manageable_event_ids(actor: scraper, request: api_request, event_ids: [event.id])
     assert_equal [], CourseEventLinkingEligibility.actor_manageable_event_ids(actor: scraper, request: nil, event_ids: [event.id])
   end
 

--- a/test/unit/course_event_linking_eligibility_test.rb
+++ b/test/unit/course_event_linking_eligibility_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+class CourseEventLinkingEligibilityTest < ActiveSupport::TestCase
+  test 'normalize_event_ids removes blanks, zeros, and duplicates' do
+    assert_equal [1, 2], CourseEventLinkingEligibility.normalize_event_ids(['', '1', '2', '2', 0, '0', nil])
+  end
+
+  test 'actor_manageable_event_ids uses policy manage? to filter ids' do
+    event = events(:one)
+
+    assert_equal [event.id], CourseEventLinkingEligibility.actor_manageable_event_ids(actor: users(:regular_user), request: nil, event_ids: [event.id])
+    assert_equal [], CourseEventLinkingEligibility.actor_manageable_event_ids(actor: users(:another_regular_user), request: nil, event_ids: [event.id])
+    assert_equal [event.id], CourseEventLinkingEligibility.actor_manageable_event_ids(actor: users(:curator), request: nil, event_ids: [event.id])
+  end
+
+  test 'actor_manageable_event_ids respects request-sensitive scraper_user permissions' do
+    event = events(:one)
+    scraper = users(:scraper_user)
+
+    api_format = Struct.new(:json?).new(true)
+    api_request = Struct.new(:post?, :put?, :patch?, :format).new(true, false, false, api_format)
+    non_api_request = Struct.new(:post?, :put?, :patch?, :format).new(false, false, false, api_format)
+
+    assert_equal [event.id], CourseEventLinkingEligibility.actor_manageable_event_ids(actor: scraper, request: api_request, event_ids: [event.id])
+    assert_equal [], CourseEventLinkingEligibility.actor_manageable_event_ids(actor: scraper, request: non_api_request, event_ids: [event.id])
+    assert_equal [], CourseEventLinkingEligibility.actor_manageable_event_ids(actor: scraper, request: nil, event_ids: [event.id])
+  end
+
+  test 'owner_can_manage_event? is request-agnostic and matches expected roles' do
+    event = events(:one)
+
+    assert CourseEventLinkingEligibility.owner_can_manage_event?(owner: users(:regular_user), event: event)
+    assert_not CourseEventLinkingEligibility.owner_can_manage_event?(owner: users(:another_regular_user), event: event)
+    assert CourseEventLinkingEligibility.owner_can_manage_event?(owner: users(:curator), event: event)
+    assert_not CourseEventLinkingEligibility.owner_can_manage_event?(owner: users(:scraper_user), event: event)
+  end
+
+  test 'owner_manageable_event_ids filters by owner manage rules' do
+    event = events(:one)
+
+    assert_equal [event.id], CourseEventLinkingEligibility.owner_manageable_event_ids(owner: users(:regular_user), event_ids: [event.id])
+    assert_equal [], CourseEventLinkingEligibility.owner_manageable_event_ids(owner: users(:another_regular_user), event_ids: [event.id])
+  end
+
+  test 'pending_claim_conflict_event_ids returns events pending for other courses' do
+    event = events(:one)
+    course = courses(:one)
+    other_course = courses(:two)
+
+    CoursePendingEvent.create!(course: course, event: event)
+
+    assert_equal [event.id], CourseEventLinkingEligibility.pending_claim_conflict_event_ids(event_ids: [event.id])
+    assert_equal [], CourseEventLinkingEligibility.pending_claim_conflict_event_ids(event_ids: [event.id], course_id: course.id)
+    assert_equal [event.id], CourseEventLinkingEligibility.pending_claim_conflict_event_ids(event_ids: [event.id], course_id: other_course.id)
+  end
+
+  test 'lock_events_for_update returns events in deterministic id order' do
+    ids = [events(:two).id, events(:one).id]
+    locked = CourseEventLinkingEligibility.lock_events_for_update(ids)
+
+    assert_equal ids.sort, locked.map(&:id)
+  end
+end


### PR DESCRIPTION
## Allow regular users to select events when creating/editing unapproved courses                                                                                                 
                                                                                                                                                                                 
  ### Problem                                                                                                                                                                      
                                                                                                                                                                                 
  Regular users couldn't select events when creating or editing a course because the course starts as "awaiting review" — and events can only be linked to approved courses. This  
  meant users had to create the course first, wait for admin approval, then come back to add events. Poor UX.                                                                      

  ### Solution

  We introduced a "pending selections" system. When a regular user picks events on an unapproved course, those selections are saved separately (not as real links). When an admin
  later approves the course, the selections are converted into real event links automatically. If the admin declines the course, the selections are simply discarded.

  Admin users bypass this entirely — their courses are auto-approved, so events link immediately as before.

  ### Changes

  **New table: `course_pending_events`**
  - Stores event selections for unapproved courses
  - Each event can only be claimed by one course at a time (unique constraint on `event_id`)
  - Automatically cleaned up when a course or event is deleted (FK cascade)

  **Course form**
  - Events selector now works for all users on all courses
  - Unapproved courses: selections saved as pending claims
  - Approved courses: events linked/unlinked directly (existing behavior)

  **Approval/decline workflow**
  - When a course is approved, all pending selections are validated and linked in a single transaction — if any event is no longer valid (deleted, unapproved, already linked
  elsewhere), the approval fails cleanly with no partial changes
  - When a course is declined, all pending selections are cleared and those events become available for other courses

  **Security**
  - If a user can't view an event that's in their selections, it shows as "Selected event (restricted)" instead of revealing the event title
  - Error messages don't reveal which specific events caused validation failures
  - Automated scraper accounts are blocked from creating pending claims

  **Bug fix**
  - Fixed an issue where the admin notification for status changes was firing even on failed form submissions

  **Tests**
  - ~30 new controller tests, plus new integration and unit test files
  - All 1,297 tests pass

  ### Migration

  Run migrations to create the `course_pending_events` table:

  ```bash
  docker-compose run --rm app bundle exec rails db:migrate
   ```
  
  ### Manual testing

  As a regular user:
  1. Create a course and select some events — course saves as "awaiting review" with a notice showing "N event selections pending"
  2. Edit the course, change selections — notice updates accordingly

  As an admin:
  1. Create a course with events — events link immediately, no pending notice
  2. Approve a regular user's course — pending events become real links
  3. Try approving when a pending event is already linked elsewhere — approval is blocked with an error
  4. Decline a course — pending selections are cleared

  Automated:

  ```
  docker-compose run --rm test bundle exec rails test
  ```
