### PR TITLE
task/remove the scilifelab affiliation field from the course catalogue

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -52,10 +52,8 @@ class CoursesController < ApplicationController
   def create
     authorize Course
     normalize_authors_and_contributors
-    normalize_node_ids
     @course = Course.new(course_params)
     @course.user = current_user if @course.respond_to?(:user=)
-
     respond_to do |format|
       if @course.save
         @course.create_activity :create, owner: current_user if @course.respond_to?(:create_activity)
@@ -72,7 +70,6 @@ class CoursesController < ApplicationController
   def update
     authorize @course
     normalize_authors_and_contributors
-    normalize_node_ids
 
     respond_to do |format|
       if @course.update(course_params)
@@ -150,8 +147,7 @@ class CoursesController < ApplicationController
       { authors: [:name, :affiliation, :orcid, :email] },
       { contributors: [:name, :affiliation, :orcid, :email] },
       { event_ids: [] },
-      { content_provider_ids: [] },
-      { node_ids: [] }
+      { content_provider_ids: [] }
     ]
 
     permitted.delete(:user_id) unless current_user&.is_admin?
@@ -189,12 +185,6 @@ class CoursesController < ApplicationController
     rescue JSON::ParserError => e
       Rails.logger.warn("CoursesController#normalize_authors_and_contributors: invalid JSON for #{key}: #{e.message}")
       params[:course].delete(key)
-    end
-  end
-
-  def normalize_node_ids
-    if params[:course][:node_ids].is_a?(String)
-      params[:course][:node_ids] = [params[:course][:node_ids]]
     end
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -17,6 +17,7 @@ class Course < ApplicationRecord
   before_create :set_course_initial_status
   after_commit :run_course_approval_lifecycle_on_create, on: :create
   after_commit :run_course_approval_lifecycle_on_status_change, on: :update
+  before_validation :set_default_node, on: :create
 
   if TeSS::Config.solr_enabled
     searchable do
@@ -54,7 +55,6 @@ class Course < ApplicationRecord
 
   validates :target_audience, presence: true
   validates :content_providers, presence: true
-  validates :node_ids, presence: true, if: -> { TeSS::Config.feature['nodes'] && Node.all.count > 0  }
   clean_array_fields(:keywords, :target_audience)
 
   validate :cannot_unapprove_with_approved_events
@@ -153,5 +153,13 @@ class Course < ApplicationRecord
     return unless events.where(event_status: Event.event_statuses[:approved]).exists?
 
     errors.add(:course_status, :cannot_unapprove_with_approved_instances)
+  end
+
+
+  def set_default_node
+    if TeSS::Config.feature['nodes'] && Node.all.count > 0
+      default_node = Node.find_by(slug: Node::SCILIFE_LAB_NODE_SLUG)
+      self.nodes << default_node if default_node
+    end
   end
 end

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -123,24 +123,6 @@
   </div>
 
 
-  <!-- Nodes: check feature enabled -->
-  <% if TeSS::Config.feature['nodes'] and Node.all.count > 0 %>
-    <div class="form-group">
-      <label>* My course is affiliated with SciLifeLab: </label>
-
-      <% Node.order(:name).each do |node| %>
-        <div>
-          <%= f.radio_button :node_ids, node.id, checked: (@course.node_ids.include?(node.id)) %>
-          <%= f.label :node_ids, (node.slug == Node::SCILIFE_LAB_NODE_SLUG ? "Yes" : "No"), value: node.id %>
-        </div>
-      <% end %>
-      <% if @course.errors[:node_ids].any? %>
-        <span style="color: #a02622"><%= @course.errors[:node_ids].join(", ") %></span>
-      <% end %>
-    </div>
-  <% end %>
-
-
   <div class="form-group">
     <%= f.submit (f.object.new_record? ? "Add" : "Update") + " course", :class => 'btn btn-primary' %>
     <%= link_to 'Back', :back, class: 'btn btn-default' %>

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -54,7 +54,6 @@ class CourseTest < ActiveSupport::TestCase
       :prerequisites_technical,
       :target_audience,
       :content_providers,
-      :node_ids
     ]
 
     blank_fields.each do |field|
@@ -73,17 +72,89 @@ class CourseTest < ActiveSupport::TestCase
     assert_includes course.errors[:content_providers], "can't be blank"
   end
 
-  test "is invalid without nodes if nodes feature is enabled" do
+  test "attaches default node on create when nodes feature enabled" do
+    original_value = TeSS::Config.feature['nodes']
     TeSS::Config.feature['nodes'] = true
-    node = Node.new(user: @user, name: 'test course node')
-    parameters = @mandatory.merge({
-                                    content_providers: [@content_providers],
-                                    user: @user
-                                  })
 
-    course = Course.new(parameters)
-    assert_not course.valid?
-    assert_includes course.errors[:node_ids], "can't be blank"
+    default_node = Node.create!(
+      slug: Node::SCILIFE_LAB_NODE_SLUG,
+      name: "SciLifeLab",
+      user: @user
+    )
+
+    course = Course.create!(
+      @mandatory.merge(
+        content_providers: [@content_providers],
+        user: @user
+      )
+    )
+
+    assert_includes course.nodes, default_node
+  ensure
+    TeSS::Config.feature['nodes'] = original_value
+  end
+
+  test "does not attach default node when nodes feature disabled" do
+    original_value = TeSS::Config.feature['nodes']
+    TeSS::Config.feature['nodes'] = false
+
+    Node.create!(
+      slug: Node::SCILIFE_LAB_NODE_SLUG,
+      name: "SciLifeLab",
+      user: @user
+    )
+
+    course = Course.create!(
+      @mandatory.merge(
+        content_providers: [@content_providers],
+        user: @user
+      )
+    )
+
+    assert_empty course.nodes
+  ensure
+    TeSS::Config.feature['nodes'] = original_value
+  end
+
+  test "does not attach node if default node not found" do
+    original_value = TeSS::Config.feature['nodes']
+    TeSS::Config.feature['nodes'] = false
+
+    course = Course.create!(
+      @mandatory.merge(
+        content_providers: [@content_providers],
+        user: @user
+      )
+    )
+
+    assert_empty course.nodes
+  ensure
+    TeSS::Config.feature['nodes'] = original_value
+  end
+
+  test "does not attach default node on update" do
+    original_value = TeSS::Config.feature['nodes']
+    TeSS::Config.feature['nodes'] = false
+
+    default_node = Node.create!(
+      slug: Node::SCILIFE_LAB_NODE_SLUG,
+      name: "SciLifeLab",
+      user: @user
+    )
+
+    course = Course.create!(
+      @mandatory.merge(
+        content_providers: [@content_providers],
+        user: @user
+      )
+    )
+
+    course.nodes.clear
+    course.update!(title: "Updated title")
+
+    assert_empty course.nodes
+  ensure
+    TeSS::Config.feature['nodes'] = original_value
   end
 
   test "is valid without nodes if nodes feature is disabled" do

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -118,7 +118,7 @@ class CourseTest < ActiveSupport::TestCase
 
   test "does not attach node if default node not found" do
     original_value = TeSS::Config.feature['nodes']
-    TeSS::Config.feature['nodes'] = false
+    TeSS::Config.feature['nodes'] = true
 
     course = Course.create!(
       @mandatory.merge(
@@ -127,14 +127,14 @@ class CourseTest < ActiveSupport::TestCase
       )
     )
 
-    assert_empty course.nodes
+    assert_empty course.nodes, "Expected no nodes to be attached because default node is missing"
   ensure
     TeSS::Config.feature['nodes'] = original_value
   end
 
   test "does not attach default node on update" do
     original_value = TeSS::Config.feature['nodes']
-    TeSS::Config.feature['nodes'] = false
+    TeSS::Config.feature['nodes'] = true
 
     default_node = Node.create!(
       slug: Node::SCILIFE_LAB_NODE_SLUG,


### PR DESCRIPTION
Ticket: [We should remove the yes/no scilifelab affiliation field from the course catalogue#386](https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/386) 