### PR TITLE
add help text in catalogue and rename the label to Training(s)

### DIFF
--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -7,7 +7,7 @@ module CoursesHelper
     The purpose of the catalogue is to provide an overview of all training opportunities available at #{TeSS::Config.site['title_short']}.
     It allows potential participants to discover and connect with courses, even when no upcoming session is currently scheduled.
 
-    To get started, click "create catalogue entry" and complete the form with the relevant information.
+    To get started, click "create catalogue entry" and complete the form with the relevant information. Once the form is submitted, it will be reviewed by our moderators.
   TEXT
 
   def course_section_card(title, options = {}, &block)

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -73,7 +73,7 @@
 
   <!-- Field: Events -->
   <div class="field">
-    <%= f.label :event_ids, "Event(s)", class: "control-label" %>
+    <%= f.label :event_ids, "Training(s)", class: "control-label" %>
     <span class="glyphicon"
           style="cursor: default; font-size: small;"
           title="<%= t('courses.hints.event_hint') %>">


### PR DESCRIPTION
**Summary of changes**

Added one line in the help text in the i icon of the training catalogue and also changed the label from Event(s) to Training(s) in New Catalogue create page.
Screenshot attached below.
Help text:
**Once the form is submitted, it will be reviewed by our moderators**

<img width="1918" height="238" alt="image" src="https://github.com/user-attachments/assets/cf06f6f4-d674-4246-8b64-829429cbe4c5" />
<img width="612" height="1394" alt="image" src="https://github.com/user-attachments/assets/518652ec-eb3a-4fef-9956-80fe8b45fea0" />
