### PR TITLE
bug/renaming_to_training_catalogue#407

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -32,10 +32,6 @@
       <div class="courses-index__pagination">
         <%= render partial: "search/common/pagination_bar", locals: { resources: @courses } %>
       </div>
-    <% else %>
-      <div class="courses-index__empty">
-        <p>No courses found. Adjust your filters or search to discover available courses.</p>
-      </div>
     <% end %>
   </div>
 


### PR DESCRIPTION
Ticket: [Fix the bug related to renaming to training catalogue#407](https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/407)

---

In this PR, I removed the code that displayed additional information which was inconsistent with the Events UI.

Before removing the code, the course search page displayed the following when no entries were found:


<img width="2800" height="1034" alt="image" src="https://github.com/user-attachments/assets/af95a0b4-1ab7-44d7-a434-421886251b21" />

And this was another example of the event search page with no entries found:
<img width="2060" height="870" alt="image" src="https://github.com/user-attachments/assets/5f29b424-312f-4cc8-a55e-6342234c7e68" />


And this was another example of the content providers search page with no entries found:
<img width="2800" height="1034" alt="image" src="https://github.com/user-attachments/assets/57da6527-928e-430b-92d4-2b89db0d0d68" />


After removing the code, the course search page now appears as follows when no entries are found:
<img width="2800" height="1034" alt="image" src="https://github.com/user-attachments/assets/66e50ac2-22e2-4bea-b724-90a677df22a4" />
