### PR TITLE
Allow linking approved Training events to non-approved Training Catalogue entries

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -55,12 +55,20 @@ class CoursesController < ApplicationController
     @course = Course.new(course_params)
     @course.user = current_user if @course.respond_to?(:user=)
     respond_to do |format|
-      if @course.save
-        @course.create_activity :create, owner: current_user if @course.respond_to?(:create_activity)
-        format.html { redirect_to @course, notice: 'Course was successfully created.' }
-        format.json { render :show, status: :created, location: @course }
-      else
-        format.html { render :new }
+      begin
+        if @course.save
+          @course.create_activity :create, owner: current_user if @course.respond_to?(:create_activity)
+          format.html { redirect_to @course, notice: 'Course was successfully created.' }
+          format.json { render :show, status: :created, location: @course }
+        else
+          set_selected_ids_for_form
+          format.html { render :new, status: :unprocessable_entity }
+          format.json { render json: @course.errors, status: :unprocessable_entity }
+        end
+      rescue ActiveRecord::RecordNotSaved => e
+        merge_event_linking_errors_from_exception(e)
+        set_selected_ids_for_form
+        format.html { render :new, status: :unprocessable_entity }
         format.json { render json: @course.errors, status: :unprocessable_entity }
       end
     end
@@ -72,12 +80,20 @@ class CoursesController < ApplicationController
     normalize_authors_and_contributors
 
     respond_to do |format|
-      if @course.update(course_params)
-        @course.create_activity(:update, owner: current_user) if @course.respond_to?(:create_activity)
-        format.html { redirect_to @course, notice: 'Course was successfully updated.' }
-        format.json { render :show, status: :ok, location: @course }
-      else
-        format.html { render :edit }
+      begin
+        if @course.update(course_params)
+          @course.create_activity(:update, owner: current_user) if @course.respond_to?(:create_activity)
+          format.html { redirect_to @course, notice: 'Course was successfully updated.' }
+          format.json { render :show, status: :ok, location: @course }
+        else
+          set_selected_ids_for_form
+          format.html { render :edit, status: :unprocessable_entity }
+          format.json { render json: @course.errors, status: :unprocessable_entity }
+        end
+      rescue ActiveRecord::RecordNotSaved => e
+        merge_event_linking_errors_from_exception(e)
+        set_selected_ids_for_form
+        format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @course.errors, status: :unprocessable_entity }
       end
     end
@@ -185,6 +201,34 @@ class CoursesController < ApplicationController
     rescue JSON::ParserError => e
       Rails.logger.warn("CoursesController#normalize_authors_and_contributors: invalid JSON for #{key}: #{e.message}")
       params[:course].delete(key)
+    end
+  end
+
+  def set_selected_ids_for_form
+    raw_params = params[:course]
+    has_raw_params = raw_params.is_a?(ActionController::Parameters) || raw_params.is_a?(Hash)
+
+    @selected_content_providers_id =
+      if has_raw_params && (raw_params.key?(:content_provider_ids) || raw_params.key?('content_provider_ids'))
+        Array(raw_params[:content_provider_ids]).reject(&:blank?).map(&:to_i)
+      else
+        @course&.content_provider_ids || []
+      end
+
+    @selected_events_id =
+      if has_raw_params && (raw_params.key?(:event_ids) || raw_params.key?('event_ids'))
+        Array(raw_params[:event_ids]).reject(&:blank?).map(&:to_i)
+      else
+        @course&.event_ids || []
+      end
+  end
+
+  def merge_event_linking_errors_from_exception(exception)
+    record = exception.respond_to?(:record) ? exception.record : nil
+    if record&.respond_to?(:errors) && record.errors.any?
+      record.errors.full_messages.each { |message| @course.errors.add(:events, message) }
+    elsif @course.errors.empty?
+      @course.errors.add(:events, I18n.t('courses.messages.event_linking_failed'))
     end
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -206,21 +206,20 @@ class CoursesController < ApplicationController
 
   def set_selected_ids_for_form
     raw_params = params[:course]
-    has_raw_params = raw_params.is_a?(ActionController::Parameters) || raw_params.is_a?(Hash)
 
     @selected_content_providers_id =
-      if has_raw_params && (raw_params.key?(:content_provider_ids) || raw_params.key?('content_provider_ids'))
-        Array(raw_params[:content_provider_ids]).reject(&:blank?).map(&:to_i)
-      else
-        @course&.content_provider_ids || []
-      end
+      selected_ids_for_form_field(raw_params, :content_provider_ids, fallback: @course&.content_provider_ids || [])
 
     @selected_events_id =
-      if has_raw_params && (raw_params.key?(:event_ids) || raw_params.key?('event_ids'))
-        Array(raw_params[:event_ids]).reject(&:blank?).map(&:to_i)
-      else
-        @course&.event_ids || []
-      end
+      selected_ids_for_form_field(raw_params, :event_ids, fallback: @course&.event_ids || [])
+  end
+
+  def selected_ids_for_form_field(raw_params, key, fallback:)
+    return fallback unless raw_params.is_a?(ActionController::Parameters) || raw_params.is_a?(Hash)
+    return fallback unless raw_params.key?(key) || raw_params.key?(key.to_s)
+
+    values = raw_params[key] || raw_params[key.to_s]
+    Array(values).reject(&:blank?).map(&:to_i)
   end
 
   def merge_event_linking_errors_from_exception(exception)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -17,7 +17,6 @@ class Course < ApplicationRecord
   before_create :set_course_initial_status
   after_commit :run_course_approval_lifecycle_on_create, on: :create
   after_commit :run_course_approval_lifecycle_on_status_change, on: :update
-  after_save :nullify_events_on_decline, if: :course_status_just_declined?
   before_validation :set_default_node, on: :create
 
   if TeSS::Config.solr_enabled
@@ -124,14 +123,6 @@ class Course < ApplicationRecord
       self,
       notifier: Notifications::CourseNotifier.new(self)
     ).after_status_change
-  end
-
-  def course_status_just_declined?
-    saved_change_to_course_status? && declined?
-  end
-
-  def nullify_events_on_decline
-    events.update_all(course_id: nil)
   end
 
   def self.extract_check_exists_attributes(course_params)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -17,6 +17,7 @@ class Course < ApplicationRecord
   before_create :set_course_initial_status
   after_commit :run_course_approval_lifecycle_on_create, on: :create
   after_commit :run_course_approval_lifecycle_on_status_change, on: :update
+  after_save :nullify_events_on_decline, if: :course_status_just_declined?
   before_validation :set_default_node, on: :create
 
   if TeSS::Config.solr_enabled
@@ -123,6 +124,14 @@ class Course < ApplicationRecord
       self,
       notifier: Notifications::CourseNotifier.new(self)
     ).after_status_change
+  end
+
+  def course_status_just_declined?
+    saved_change_to_course_status? && declined?
+  end
+
+  def nullify_events_on_decline
+    events.update_all(course_id: nil)
   end
 
   def self.extract_check_exists_attributes(course_params)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -600,17 +600,13 @@ class Event < ApplicationRecord
   def course_must_be_approved_for_course_instance
     return unless course.present?
 
-    if !course.approved? && (new_record? || will_save_change_to_course_id?)
-      errors.add(:course, :must_be_approved_for_course_instance)
-    end
+    return unless new_record? || will_save_change_to_course_id?
 
-    return unless will_save_change_to_event_status?
+    course_or_event_approved = course.approved? || approved?
+    either_declined = course.declined? || declined?
+    return if course_or_event_approved && !either_declined
 
-    _old_status, new_status = event_status_change_to_be_saved
-    return unless new_status == 'approved'
-    return if course.approved?
-
-    errors.add(:event_status, :cannot_be_approved_until_course_is_approved)
+    errors.add(:course, :must_be_approved_for_course_instance)
   end
 
   def allowed_url

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -84,9 +84,9 @@
                  { include_blank: false },
                  { class: "js-select2", style: "width: 100%;", multiple: true } %>
 
-    <% if @course.errors[:content_providers].present? %>
+    <% if @course.errors[:events].present? || @course.errors[:event_ids].present? %>
     <span class="help-block small" style="color: #a02622;">
-      <%= @course.errors[:content_providers].join(', ') %>
+      <%= (@course.errors[:events] + @course.errors[:event_ids]).uniq.join(', ') %>
     </span>
     <% else %>
       <span class="help-block small">Select any potential upcoming instances of your catalogue entry</span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,9 +82,7 @@ en:
         event:
           attributes:
             course:
-              must_be_approved_for_course_instance: 'must be approved before you can create a course instance.'
-            event_status:
-              cannot_be_approved_until_course_is_approved: 'cannot be approved until the associated course is approved.'
+              must_be_approved_for_course_instance: 'linking is allowed only when either the catalogue entry or the training session is approved, and neither is declined.'
   about:
     registry: >
       TeSS is a platform that was developed to provide a one-stop shop for trainers and trainees to discover
@@ -551,6 +549,7 @@ en:
     actions:
       create_instance: 'Announce an upcoming training'
     messages:
+      event_linking_failed: 'One or more selected training sessions could not be linked to this catalogue entry.'
       not_approved_instance_help: 'This catalogue entry is not approved yet. You can create training instances once it is approved.'
     event_option_status:
       awaiting_review: 'Pending review'

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -463,6 +463,29 @@ class CoursesControllerTest < ActionController::TestCase
     assert_redirected_to course_path(updated_course)
   end
 
+  test 'should render edit when trying to link event to declined course' do
+    sign_in users(:admin)
+
+    course = Course.create!(
+      @mandatory.merge(
+        nodes: [@node],
+        content_providers: [@content_providers],
+        user: users(:regular_user)
+      )
+    )
+    course.update_column(:course_status, Course.course_statuses[:declined])
+
+    event = events(:one)
+    assert_nil event.course_id
+
+    patch :update, params: { id: course.id, course: { event_ids: [event.id] } }
+
+    assert_response :unprocessable_entity
+    assert_template :edit
+    assert assigns(:course).errors.any?
+    assert_nil event.reload.course_id
+  end
+
   # DESTROY TESTS
   test 'should destroy course owned by user' do
     sign_in users(:regular_user)

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -197,6 +197,39 @@ class CourseTest < ActiveSupport::TestCase
     assert_includes course.content_providers, @content_providers
   end
 
+  test "can attach approved events to an unapproved course" do
+    course = Course.create!(
+      @mandatory.merge(
+        nodes: [@node],
+        content_providers: [@content_providers],
+        user: @user
+      )
+    )
+    assert course.awaiting_review?
+
+    event = events(:one) # approved by default
+    assert event.approved?
+
+    assert course.update(event_ids: [event.id])
+    assert_equal course.id, event.reload.course_id
+  end
+
+  test "declining a course unlinks its events" do
+    course = Course.create!(
+      @mandatory.merge(
+        nodes: [@node],
+        content_providers: [@content_providers],
+        user: @user
+      )
+    )
+
+    event = events(:one)
+    assert event.update(course: course)
+
+    assert course.update(course_status: Course.course_statuses[:declined])
+    assert_nil event.reload.course_id
+  end
+
   test "has many events dependent nullify" do
     course = Course.create!(@mandatory.merge(user: users(:trusted_user), content_providers: [@content_providers], nodes: [@node]))
     event = events(:one)

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -214,7 +214,7 @@ class CourseTest < ActiveSupport::TestCase
     assert_equal course.id, event.reload.course_id
   end
 
-  test "declining a course unlinks its events" do
+  test "declining a course keeps its linked events" do
     course = Course.create!(
       @mandatory.merge(
         nodes: [@node],
@@ -227,7 +227,7 @@ class CourseTest < ActiveSupport::TestCase
     assert event.update(course: course)
 
     assert course.update(course_status: Course.course_statuses[:declined])
-    assert_nil event.reload.course_id
+    assert_equal course.id, event.reload.course_id
   end
 
   test "has many events dependent nullify" do

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -863,7 +863,23 @@ class EventTest < ActiveSupport::TestCase
     assert_includes event.errors[:course], I18n.t('activerecord.errors.models.event.attributes.course.must_be_approved_for_course_instance')
   end
 
-  test 'event linked to an unapproved course cannot be approved' do
+  test 'can link an approved event to an unapproved course' do
+    course = courses(:one) # awaiting_review by default
+    event = events(:one)   # approved by default
+
+    assert event.update(course: course)
+  end
+
+  test 'cannot link an event to a declined course' do
+    course = courses(:one)
+    course.update_column(:course_status, Course.course_statuses[:declined])
+    event = events(:one)
+
+    refute event.update(course: course)
+    assert_includes event.errors[:course], I18n.t('activerecord.errors.models.event.attributes.course.must_be_approved_for_course_instance')
+  end
+
+  test 'event linked to an unapproved course can be approved' do
     course = courses(:one)
     course.update_column(:course_status, Course.course_statuses[:approved])
 
@@ -879,10 +895,6 @@ class EventTest < ActiveSupport::TestCase
 
     course.update_column(:course_status, Course.course_statuses[:awaiting_review])
 
-    refute event.update(event_status: Event.event_statuses[:approved])
-    assert_includes event.errors[:event_status], I18n.t('activerecord.errors.models.event.attributes.event_status.cannot_be_approved_until_course_is_approved')
-
-    course.update_column(:course_status, Course.course_statuses[:approved])
     assert event.update(event_status: Event.event_statuses[:approved])
   end
 


### PR DESCRIPTION
## Summary
  Fixes #383 by allowing approved Training events to be attached to Training Catalogue entries that
  are still `awaiting_review` or `revision_required`.

  ## What changed
  - Relaxed event-course validation in `Event`:
    - allow linking when course is not approved, as long as the event is approved
    - still block linking to declined courses
    - removed the rule that blocked approving an event until its course was approved
  - Added cleanup in `Course`:
    - when a course is moved to `declined`, linked events are unlinked (`course_id = nil`)
  - Improved UX/error handling:
    - failed event linking now returns form validation errors (422) instead of a 500
    - course form now shows event-related errors clearly
  - Added/updated model and controller tests for these flows

  ## Why this approach
  This is a minimal fix (no new tables/associations/workflows) and matches the agreed workflow
  matrix.

  ## QA focus
  1. Regular user can link an approved event to `awaiting_review` course.
  2. Same works for `revision_required` course.
  3. Declining a course unlinks its events.
  4. Trying to link to a declined course shows validation error (no 500).
  5. Event approval remains independent from course approval status.