### PR TITLE
fix event dropdown in course form

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -175,9 +175,12 @@ class CoursesController < ApplicationController
     params.require(:course).permit(:title, :url, :content_provider_id, content_provider_ids: [])
   end
 
+  # Loads content providers and prepares a list of events for course forms,
+  # filtering approved events not linked to other courses
   def set_course_dependencies
     @content_providers = ContentProvider.all
-    approved_events = Event.where(event_status: Event.event_statuses[:approved])
+    approved_events = Event.where(event_status: Event.event_statuses[:approved]).where(course_id: nil)
+
     @events = if defined?(@course) && @course&.persisted?
                 approved_events.or(Event.where(id: @course.event_ids)).distinct.order(:title)
               else

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -43,13 +43,9 @@ module CoursesHelper
   end
 
   def course_event_option_label(event)
-    return event.title if event.blank?
+    return event.title if event.approved?
 
-    status = event.respond_to?(:event_status) ? event.event_status : nil
-    return event.title if status.blank? || status == 'approved'
-
-    suffix = I18n.t("courses.event_option_status.#{status}", default: status.humanize)
-
+    suffix = I18n.t("courses.event_option_status.#{event.event_status}", default: event.event_status.humanize)
     "#{event.title} (#{suffix})"
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -49,14 +49,14 @@ class Course < ApplicationRecord
 
 
   validates :title, :url, :language, :description,
-            :structure_and_duration, :learning_outcomes,
+            :structure_and_duration, :learning_outcomes, :licence,
             :prerequisites_knowledge, :prerequisites_technical,
             presence: true
 
   validates :target_audience, presence: true
   validates :content_providers, presence: true
   clean_array_fields(:keywords, :target_audience)
-
+  validate :events_not_linked_to_other_courses
   validate :cannot_unapprove_with_approved_events
 
 
@@ -98,6 +98,7 @@ class Course < ApplicationRecord
     self.course_status = :approved if self.user.admin_or_trusted?
   end
 
+  #@todo need to refactored to more generic behaviour with arguments
   def course_status_just_approved?
     return false unless previous_changes.key?("course_status")
 
@@ -110,6 +111,7 @@ class Course < ApplicationRecord
     old_status.in?([awaiting_review, revisions_required]) &&
       new_status == approved
   end
+
   def run_course_approval_lifecycle_on_create
     ApprovalLifecycle.new(
       self,
@@ -162,4 +164,22 @@ class Course < ApplicationRecord
       self.nodes << default_node if default_node
     end
   end
+
+  def events_not_linked_to_other_courses
+    return if events.blank?
+    # Only check in the database, ignore the in-memory assignment to self
+    events.each do |event|
+      # Reload the event from DB to get its current course
+      db_event = Event.find(event.id)
+
+      # Skip if it's linked to this course (editing)
+      next if db_event.course_id == self.id
+
+      # Fail if it's linked to any other course
+      if db_event.course_id.present?
+        errors.add(:events, "Event '#{db_event.title}' is already linked to another course")
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Ticket: [Event should show error on getting attached to another catalogue#411](https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/411)

Changes
- In the course form (create and update), the events dropdown now only shows approved events that are not already linked to another course.
- Added backend validation to prevent assigning events that are already linked, in case frontend restrictions are bypassed.
- Made licence mandatory in the courses form.
