### PR TITLE
Fix/catalogue sorting as title_asc

### DIFF
--- a/app/controllers/concerns/searchable_index.rb
+++ b/app/controllers/concerns/searchable_index.rb
@@ -56,7 +56,13 @@ module SearchableIndex
 
     @facet_params = params.permit(*@model.facet_keys_with_multiple).to_h
     @search_params = params[:q] || ''
-    @sort_by = params[:sort].blank? ? 'default' : params[:sort]
+    @sort_by = if params[:sort].present?
+                 params[:sort]
+               elsif @model.name == 'Course'
+                 'asc'
+               else
+                 'default'
+               end
   end
 
   def api_collection_properties

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -73,7 +73,7 @@ module Searchable
             when 'Material'
               order_by(:created_at, :desc)
             when 'Course'
-              order_by(:created_at, :desc)
+              order_by(:sort_title, :asc)
             else
               order_by(:sort_title, :asc)
           end

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -83,6 +83,44 @@ class CoursesControllerTest < ActionController::TestCase
     end
   end
 
+  test 'courses index defaults to title ascending when sort param is missing' do
+    with_settings(solr_enabled: true) do
+      captured_sort = nil
+      search_stub = proc do |*_args, **kwargs|
+        options = kwargs.presence || (_args.last.is_a?(Hash) ? _args.last : {})
+        captured_sort = options[:sort_by]
+        MockSearch.new(Course.all)
+      end
+
+      Course.stub(:search_and_filter, search_stub) do
+        get :index
+        assert_response :success
+      end
+
+      assert_equal 'asc', captured_sort
+      assert_equal 'asc', assigns(:sort_by)
+    end
+  end
+
+  test 'courses index uses explicit sort param when provided' do
+    with_settings(solr_enabled: true) do
+      captured_sort = nil
+      search_stub = proc do |*_args, **kwargs|
+        options = kwargs.presence || (_args.last.is_a?(Hash) ? _args.last : {})
+        captured_sort = options[:sort_by]
+        MockSearch.new(Course.all)
+      end
+
+      Course.stub(:search_and_filter, search_stub) do
+        get :index, params: { sort: 'new' }
+        assert_response :success
+      end
+
+      assert_equal 'new', captured_sort
+      assert_equal 'new', assigns(:sort_by)
+    end
+  end
+
   test 'should get index as json' do
     parameters = @mandatory.merge(
       {


### PR DESCRIPTION
**Summary of changes**

- Course catalogue at present sorts the course entries as most recent but the requirement changed to have them sorted as title ascending hence this is the motivation behind this change

**Motivation and context**

Changes made in below files:
- test/controllers/courses_controller_test.rb
-  app/controllers/concerns/searchable_index.rb
-  app/models/concerns/searchable.rb 

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
