### PR TITLE
replace the link to course catalogue

### DIFF
--- a/app/views/our_resources/trainer_community.html.erb
+++ b/app/views/our_resources/trainer_community.html.erb
@@ -50,7 +50,7 @@
                   reusable training materials, created in partnership with VIB and NBIS.<br> See the
                   <a href="https://elixir-europe-training.github.io/ELIXIR-TrP-FAIR-Material-By-Design/" target="_blank">course
                     website</a> for more information, or
-                  <a href="https://training.scilifelab.se/events/fair-training-material-by-design" target="_blank">register here</a>!
+                  <a href="https://training.scilifelab.se/courses/training-material-made-fair-by-design" target="_blank">register here</a>!
                 </p>
               </blockquote>
             </div>


### PR DESCRIPTION
**Summary of changes**
 
We have received the feedback that the register here text was redirecting to the old instance of that course in 2024 for registration hence its better to change it to catalogue link to look for an upcoming instance and get yourself registered.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
