### PR TITLE
Fix cloned event prices and escape custom audience labels

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -168,8 +168,7 @@ INFO
       arr << "#{formatted_value} #{currency_display} #{audience_part}"
     end
 
-    # Join lines with <br> and mark HTML-safe
-    lines.join("<br>").html_safe
+    safe_join(lines, tag.br)
   end
 
   def event_formatted_datetime(datetime)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -518,8 +518,11 @@ class Event < ApplicationRecord
     external_resources.each do |er|
       c.external_resources.build(url: er.url, title: er.title)
     end
-    %i[materials scientific_topics operations nodes venues cities topics content_providers event_prices].each do |field|
+    %i[materials scientific_topics operations nodes venues cities topics content_providers].each do |field|
       c.send("#{field}=", send(field))
+    end
+    event_prices.each do |ep|
+      c.event_prices.build(cost: ep.cost, currency: ep.currency, audience_type: ep.audience_type)
     end
 
     c

--- a/test/helpers/events_helper_test.rb
+++ b/test/helpers/events_helper_test.rb
@@ -78,6 +78,19 @@ class EventsHelperTest < ActionView::TestCase
     assert_equal expected.sort, get_event_audience_types(new_user).sort
   end
 
+  test "event_cost_value escapes custom audience_type content" do
+    event = Event.new
+    event.event_prices.build(cost: 10, currency: "SEK", audience_type: '<script>alert("xss")</script>')
+
+    rendered = event_cost_value(event)
+
+    assert_includes rendered, '10 SEK'
+    assert_includes rendered, '&lt;'
+    assert_includes rendered, '&gt;'
+    assert_includes rendered, '&quot;'
+    refute_includes rendered, '<script>alert("xss")</script>'
+  end
+
   test "includes custom audience types from user's previous event prices" do
     new_event_price_audience_type = "vip-academic"
     new_user = User.create!({ username: 'new_user', password: '12345678', email: 'new_user@example.com', processing_consent: '1' })

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -559,6 +559,7 @@ class EventTest < ActiveSupport::TestCase
     event = Event.new(parameters)
 
     assert event.save
+    original_price_count = event.event_prices.count
     dup = nil
     assert event.slug
 
@@ -582,8 +583,8 @@ class EventTest < ActiveSupport::TestCase
               assert_equal 1, dup.external_resources.length
               assert_equal 'test', dup.external_resources.first.title
               assert_equal 'https://external-resource.com', dup.external_resources.first.url
-              assert_equal 2, event.event_prices.length
-              assert_equal 2, dup.event_prices.length
+              assert_equal original_price_count, event.event_prices.length
+              assert_equal original_price_count, dup.event_prices.length
               assert_nil dup.event_prices.first.id
               assert_equal event.event_prices.map(&:cost), dup.event_prices.map(&:cost)
               assert_equal event.event_prices.map(&:currency), dup.event_prices.map(&:currency)
@@ -608,8 +609,8 @@ class EventTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal 2, event.reload.event_prices.count
-    assert_equal 2, dup.reload.event_prices.count
+    assert_equal original_price_count, event.reload.event_prices.count
+    assert_equal original_price_count, dup.reload.event_prices.count
     refute_equal event.event_prices.pluck(:id).sort, dup.event_prices.pluck(:id).sort
   end
 

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -582,6 +582,12 @@ class EventTest < ActiveSupport::TestCase
               assert_equal 1, dup.external_resources.length
               assert_equal 'test', dup.external_resources.first.title
               assert_equal 'https://external-resource.com', dup.external_resources.first.url
+              assert_equal 2, event.event_prices.length
+              assert_equal 2, dup.event_prices.length
+              assert_nil dup.event_prices.first.id
+              assert_equal event.event_prices.map(&:cost), dup.event_prices.map(&:cost)
+              assert_equal event.event_prices.map(&:currency), dup.event_prices.map(&:currency)
+              assert_equal event.event_prices.map(&:audience_type), dup.event_prices.map(&:audience_type)
             end
           end
         end
@@ -601,6 +607,10 @@ class EventTest < ActiveSupport::TestCase
         end
       end
     end
+
+    assert_equal 2, event.reload.event_prices.count
+    assert_equal 2, dup.reload.event_prices.count
+    refute_equal event.event_prices.pluck(:id).sort, dup.event_prices.pluck(:id).sort
   end
 
   test 'should strip attributes' do


### PR DESCRIPTION
  This PR fixes two issues in the separate course fees work:

  - duplicate events now copy `event_prices` instead of moving the original rows to the clone
  - rendered event price labels now escape custom `audience_type` values instead of marking the whole string as trusted HTML

  ## Changes

  - remove `event_prices` from the generic association-copy loop in `Event#duplicate`
  - build copied `event_prices` explicitly on the cloned event
  - replace `html_safe` in `event_cost_value` with `safe_join(lines, tag.br)`
  - add regression coverage for both clone behavior and escaped rendering