### PR TITLE
add serve teaching guide to resources

### DIFF
--- a/config/locales/overrides/traininghub.en.yml
+++ b/config/locales/overrides/traininghub.en.yml
@@ -612,6 +612,11 @@ en:
           type: 'application'
           image: 'scilifelab/fairicon-black.png'
           url: 'https://training-certificate.serve.scilifelab.se/app/training-certificate'
+        serveteachingdoc:
+          name: 'SciLifeLab Serve Guide'
+          type: 'resource collection'
+          image: 'scilifelab/circle-infra.png'
+          url: 'https://serve.scilifelab.se/docs/teaching/'
     coursematerial:
       name: 'Course Material'
       description: 'Course materials are recommended resources that have been developed as part of an intensive course.'


### PR DESCRIPTION
**Summary of changes**

- This request was came from Arnold to add the serve teaching guide to the portal resources and hence this is the motivation behind this change.


**Screenshots**

<img width="833" height="489" alt="image" src="https://github.com/user-attachments/assets/de8cb9ce-0d0c-47fd-8f34-00e5026c5e14" />


**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
