### PR TITLE
update the title of serve teaching guide resource

### DIFF
--- a/app/views/our_resources/guides.html.erb
+++ b/app/views/our_resources/guides.html.erb
@@ -21,7 +21,7 @@
               <%= link_to elements['url'], target: '_blank', style: 'text-decoration: none' do %>
                 <div class="mb-5">
                   <div class="guide-box text-center d-flex flex-column p-3">
-                    <p style="font-size:20px;"><b title="<%= elements['name'] %>"><%= truncate(elements['name'], length: 35) %></b></p>
+                    <p style="font-size:20px;"><b title="<%= elements['name'] %>"><%= truncate(elements['name'], length: 37) %></b></p>
                     <%= image_tag(asset_path(elements['image']), alt: 'guide', height: '140px') %><br><br>
                     <p id="guide-type"><%= elements['type'] %></p>
                   </div>

--- a/config/locales/overrides/traininghub.en.yml
+++ b/config/locales/overrides/traininghub.en.yml
@@ -613,7 +613,7 @@ en:
           image: 'scilifelab/fairicon-black.png'
           url: 'https://training-certificate.serve.scilifelab.se/app/training-certificate'
         serveteachingdoc:
-          name: 'SciLifeLab Serve Guide'
+          name: 'JupyterLab, RStudio & other notebooks'
           type: 'resource collection'
           image: 'scilifelab/circle-infra.png'
           url: 'https://serve.scilifelab.se/docs/teaching/'


### PR DESCRIPTION
**Summary of changes**

- Arnold requested the change of the title on the training assets page to **JupyterLab, RStudio & other notebooks** instead of serve teaching guide and hence this is the motivation behind this change.
- 
**Motivation and context**

I even changed the char limit to 37 char from 35 as this was tested and helps in improving the legibility of other titles as well.
 
**Screenshots**

<img width="1102" height="724" alt="image" src="https://github.com/user-attachments/assets/196a2d46-6e95-41c6-9d29-195e14562e81" />

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
