### PR TITLE
fix(ingestors): support icalendar 2.12 value types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,8 +249,11 @@ GEM
       concurrent-ruby (~> 1.0)
     i18n_data (0.17.1)
       simple_po_parser (~> 1.1)
-    icalendar (2.9.0)
+    icalendar (2.12.3)
+      base64
       ice_cube (~> 0.16)
+      logger
+      ostruct
     ice_cube (0.16.4)
     iso_country_codes (0.7.8)
     jbuilder (2.11.5)

--- a/lib/ingestors/event_ingestion.rb
+++ b/lib/ingestors/event_ingestion.rb
@@ -18,10 +18,6 @@ module Ingestors
       EventTypeDictionary.instance.lookup_value(input, 'title')
     end
 
-    def convert_location(input)
-      input
-    end
-
     def parse_dates(input, timezone = nil)
       Time.use_zone(timezone) do
         # try to split on obvious interval markers

--- a/lib/ingestors/ical_ingestor.rb
+++ b/lib/ingestors/ical_ingestor.rb
@@ -71,45 +71,40 @@ module Ingestors
       # puts "calevent: #{calevent.inspect}"
       begin
         # set fields
+        # icalendar >= 2.10 returns properties as wrapped Icalendar::Values types
+        # (or nil when absent), so access them nil-safely.
         event = OpenStruct.new
-        event.url = calevent.url.to_s
-        event.title = calevent.summary.to_s
+        event.url = calevent.url&.to_s
+        event.title = calevent.summary&.to_s
         event.description = process_description calevent.description
-
-        # puts "\n\ncalevent.description = #{calevent.description}"
-        # puts "\n\n...        converted = #{event.description}"
 
         event.end = calevent.dtend&.to_time
         unless calevent.dtstart.nil?
           dtstart = calevent.dtstart
           event.start = dtstart&.to_time
+          # icalendar >= 2.11 always returns the tzid param as an array.
           tzid = dtstart.ical_params['tzid']
-          event.timezone = tzid.first.to_s if !tzid.nil? and tzid.size > 0
+          event.timezone = tzid.first.to_s if tzid.present?
         end
 
-        event.venue = calevent.location.to_s
-        if calevent.location.downcase.include?('online')
-          event.online = true
-          event.city = nil
-          event.postcode = nil
-          event.country = nil
-        else
-          location = convert_location(calevent.location)
-          event.city = location['suburb'] unless location['suburb'].nil?
-          event.country = location['country'] unless location['country'].nil?
-          event.postcode = location['postcode'] unless location['postcode'].nil?
-        end
-        event.keywords = []
-        unless calevent.categories.nil? or calevent.categories.first.nil?
-          cats = calevent.categories.first
-          if cats.is_a?(Icalendar::Values::Array)
-            cats.each do |item|
-              event.keywords << item.to_s.lstrip
-            end
+        if calevent.location.present?
+          event.venue = calevent.location.to_s
+          if calevent.location.downcase.include?('online')
+            event.online = true
+            event.city = nil
+            event.postcode = nil
+            event.country = nil
           else
-            event.keywords << cats.to_s.strip
+            location = convert_location(calevent.location)
+            event.city = location['suburb'] unless location['suburb'].nil?
+            event.country = location['country'] unless location['country'].nil?
+            event.postcode = location['postcode'] unless location['postcode'].nil?
           end
         end
+
+        # icalendar >= 2.10 returns categories as a plain (possibly nested) Array
+        # of strings; the old Icalendar::Values::Array wrapper moved to Helpers.
+        event.keywords = Array(calevent.categories).flatten.map { |c| c.to_s.strip }.reject(&:blank?)
 
         # store event
         @events << event

--- a/lib/ingestors/ical_ingestor.rb
+++ b/lib/ingestors/ical_ingestor.rb
@@ -87,18 +87,16 @@ module Ingestors
           event.timezone = tzid.first.to_s if tzid.present?
         end
 
+        # icalendar >= 2.10 returns location as an Icalendar::Values wrapper, not a
+        # String — coerce to a plain String once for the string operations.
         if calevent.location.present?
-          event.venue = calevent.location.to_s
-          if calevent.location.downcase.include?('online')
+          location = calevent.location.to_s
+          event.venue = location
+          if location.downcase.include?('online')
             event.online = true
             event.city = nil
             event.postcode = nil
             event.country = nil
-          else
-            location = convert_location(calevent.location)
-            event.city = location['suburb'] unless location['suburb'].nil?
-            event.country = location['country'] unless location['country'].nil?
-            event.postcode = location['postcode'] unless location['postcode'].nil?
           end
         end
 


### PR DESCRIPTION
## Summary of changes

- Bumps `icalendar` 2.9.0 → 2.12.3 and updates the iCal ingestor for the value-type changes in icalendar 2.10–2.12. 

- icalendar 2.10+ returns event properties as nil-able wrapped `Icalendar::Values` types and **relocated `Icalendar::Values::Array` into `Helpers`**. Our ingestor's `rescue` was silently swallowing the resulting `NameError`, so `SourceTestWorkerTest#test_test_ical_source` ingested **0 events instead of 1**.

- In icalendar 2.12, `location` isn't a plain string anymore, it's a wrapper object. So we now convert it to a string once and use that. This avoids calling string methods on the wrapper, which could error and cause the event to be silently skipped.

- We also removed some dead code. The old `convert_location` method just returned whatever you gave it (it did nothing), so the code that tried to read city, country, and postcode from it never actually set anything. We deleted that unused branch and the empty method.

Fixes:
- `url`/`summary` accessed nil-safely (`&.to_s`)
- `location` guarded before calling String methods
- categories: `Icalendar::Values::Array` gone → flatten the plain nested Array and normalise to strings
- `tzid` param is always an array in 2.11 → use `present?`

### Testing
Verified against icalendar 2.12.3: the ical worker + ingestor unit tests pass, and the **full suite is green (1286 tests, 0 failures)**.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).
