### PR TITLE
ci: add non-blocking bundle-audit gem vulnerability scan

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,6 +9,9 @@ name: Gem audit
 # findings for visibility; once the backlog is cleared, remove `continue-on-error`
 # to make it a required, blocking gate.
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: .ruby-version
           bundler-cache: true   # runs bundle install and caches gems
 
       - name: Audit gems

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,41 @@
+name: Gem audit
+
+# Scans Gemfile.lock for gems with known security advisories (CVEs) using
+# bundle-audit. Runs when the Gemfile changes and once a week.
+#
+# NOTE: this is currently NON-BLOCKING (`continue-on-error: true`). The repo has
+# a pre-existing backlog of advisories (some only fixable via the Rails 7 -> 8
+# upgrade), so failing every PR now would block all work. The job reports the
+# findings for visibility; once the backlog is cleared, remove `continue-on-error`
+# to make it a required, blocking gate. Tracked in engineering-standards-todo.md.
+
+on:
+  push:
+    paths:
+      - 'Gemfile*'
+  pull_request:
+    paths:
+      - 'Gemfile*'
+  schedule:
+    - cron: '0 9 * * 1'   # every Monday 09:00 UTC
+
+jobs:
+  audit:
+    name: Audit gems for known vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install ImageMagick
+        run: sudo apt-get update && sudo apt-get install -y imagemagick
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true   # runs bundle install and caches gems
+
+      - name: Audit gems
+        continue-on-error: true   # non-blocking for now — see note at top of file
+        run: bundle exec bundle-audit check --update

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,7 +7,7 @@ name: Gem audit
 # a pre-existing backlog of advisories (some only fixable via the Rails 7 -> 8
 # upgrade), so failing every PR now would block all work. The job reports the
 # findings for visibility; once the backlog is cleared, remove `continue-on-error`
-# to make it a required, blocking gate. Tracked in engineering-standards-todo.md.
+# to make it a required, blocking gate.
 
 on:
   push:

--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ source 'https://rails-assets.org' do
 end
 
 group :development, :test do
+  gem 'bundle-audit' # scans Gemfile.lock for gems with known CVEs (run in CI + weekly)
   gem 'byebug'
   gem 'pry-byebug'
   gem 'rubocop'

--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ source 'https://rails-assets.org' do
 end
 
 group :development, :test do
-  gem 'bundle-audit' # scans Gemfile.lock for gems with known CVEs (run in CI + weekly)
+  gem 'bundle-audit', require: false # CLI-only; scans Gemfile.lock for gems with known CVEs (run in CI + weekly)
   gem 'byebug'
   gem 'pry-byebug'
   gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,11 @@ GEM
     bootstrap-tab-history-rails (0.1.0)
       railties (>= 3.1)
     builder (3.3.0)
+    bundle-audit (0.2.0)
+      bundler-audit
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     byebug (11.1.3)
     case_transform (0.2)
       activesupport
@@ -803,6 +808,7 @@ DEPENDENCIES
   bootstrap-datepicker-rails
   bootstrap-sass
   bootstrap-tab-history-rails
+  bundle-audit
   byebug
   cocoon
   committee


### PR DESCRIPTION
## Summary of changes
Adds the `bundle-audit` gem (dev/test) and a **Gem audit** workflow that scans `Gemfile.lock` for gems with known CVEs — on Gemfile changes and weekly. This mirrors upstream ElixirTeSS's `audit.yml`.

The audit step uses `continue-on-error: true` because there's still a backlog of advisories that are only fixable via the Rails upgrade. Making it blocking today would fail every PR. It reports findings for visibility now; once the Rails upgrade clears the backlog, we remove `continue-on-error` to make it a required gate.
This PR touches `Gemfile*`, so the new workflow runs on it — you'll see the Gem audit job report the current advisories.

This adds a dev/test-only gem and a CI workflow. No app/runtime or view changes.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).

