### PR TITLE
ci: add database migration test workflow

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -27,7 +27,7 @@ jobs:
       DB_NAME: tess
       DB_USER: tess
       DB_PASSWORD: password
-      SECRET_BASE_KEY: test_key
+      SECRET_KEY_BASE: test_key
       REDIS_TEST_URL: redis://localhost:6379/0
       PREV_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
 

--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -93,5 +93,19 @@ jobs:
           rm -rf db/migrate
           mv db/migrate.bkp db/migrate
 
+      - name: Restore this PR's schema.rb
+        # After loading the previous schema above, put this PR's committed
+        # schema.rb back as the baseline for the drift check below.
+        run: git checkout HEAD -- db/schema.rb
+
       - name: Run migrations
         run: bundle exec rails db:migrate
+
+      - name: Fail if db/schema.rb drifted from the migrations
+        # db:migrate re-dumps db/schema.rb; if it differs from the committed one,
+        # the schema is out of sync with the migrations.
+        run: |
+          if ! git diff --exit-code db/schema.rb; then
+            echo "::error::db/schema.rb is out of sync with the migrations. Run 'bin/rails db:migrate' locally and commit the updated db/schema.rb."
+            exit 1
+          fi

--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -79,7 +79,7 @@ jobs:
         # migrations so only the previous schema is loaded.
         if: env.PREV_SHA != '0000000000000000000000000000000000000000'
         run: |
-          git fetch origin ${{ env.PREV_SHA }}
+          git fetch --no-tags --depth=1 origin "${{ env.PREV_SHA }}"
           git checkout ${{ env.PREV_SHA }} -- db/schema.rb
           mv db/migrate db/migrate.bkp
           git checkout ${{ env.PREV_SHA }} -- db/migrate

--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -1,0 +1,97 @@
+name: Database migration tests
+
+# Verifies that new migrations apply cleanly on top of the PREVIOUS schema:
+# it loads the schema from the base commit, then runs `db:migrate` with the new
+# migrations. Catches broken migrations and db/schema.rb drift. Only runs when
+# migrations change.
+
+on:
+  push:
+    paths:
+      - 'db/migrate/**'
+  pull_request:
+    paths:
+      - 'db/migrate/**'
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    name: Run migrations against previous schema
+    runs-on: ubuntu-latest
+
+    env:
+      RAILS_ENV: test
+      DB_HOST: localhost
+      DB_NAME: tess
+      DB_USER: tess
+      DB_PASSWORD: password
+      SECRET_BASE_KEY: test_key
+      REDIS_TEST_URL: redis://localhost:6379/0
+      PREV_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_DB: tess
+          POSTGRES_USER: tess
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:6
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install ImageMagick
+        run: sudo apt-get update && sudo apt-get install -y imagemagick
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Setup test configuration files
+        run: |
+          cp test/config/test_tess.yml config/tess.yml
+          cp config/secrets.github.yml config/secrets.yml
+          cp config/ingestion.example.yml config/ingestion.yml
+
+      - name: Check out previous schema
+        # Load the base commit's schema.rb, temporarily setting aside the new
+        # migrations so only the previous schema is loaded.
+        if: env.PREV_SHA != '0000000000000000000000000000000000000000'
+        run: |
+          git fetch origin ${{ env.PREV_SHA }}
+          git checkout ${{ env.PREV_SHA }} -- db/schema.rb
+          mv db/migrate db/migrate.bkp
+          git checkout ${{ env.PREV_SHA }} -- db/migrate
+
+      - name: Load previous database schema
+        run: bundle exec rake db:test:prepare
+
+      - name: Restore new migrations
+        if: env.PREV_SHA != '0000000000000000000000000000000000000000'
+        run: |
+          rm -rf db/migrate
+          mv db/migrate.bkp db/migrate
+
+      - name: Run migrations
+        run: bundle exec rails db:migrate

--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install ImageMagick
         run: sudo apt-get update && sudo apt-get install -y imagemagick


### PR DESCRIPTION
**Summary of changes**

- Add `.github/workflows/migration-test.yml` — CI that loads the schema from the base commit, then runs the new migrations on top, on PRs/pushes touching `db/migrate/**`.
- Adapted from upstream ElixirTeSS's `migration-test.yml` using our conventions (`postgres:14`/`redis:6`, `actions/checkout@v4`, Ruby from `.ruby-version`, our env + config-file setup) plus `permissions: contents: read`.
- Upstream's Node/yarn steps are omitted, we use rails-assets and have no `yarn.lock`; re-adding the JS/yarn setup is tracked as a separate follow-up.

**Motivation and context**

Catches broken migrations and `db/schema.rb` drift before merge — a recurring pain point in this repo — and brings us to parity with upstream, which runs this check. Note: the workflow only triggers on `db/migrate/**` changes, so it won't run on this PR; it will first exercise on the next migration-touching PR. Verified the YAML is valid and the `db:test:prepare` → `db:migrate` chain runs cleanly in our test environment.

**Screenshots**

N/A – no UI changes.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated database migration checks for relevant changes.
  * Verifies migrations apply successfully against the previous database schema.
  * Confirms the resulting schema remains synchronized with the committed version.
  * Runs in a consistent test environment with PostgreSQL and Redis services.
  * Reports failures when migrations do not complete cleanly or produce unexpected schema changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->