### PR TITLE
feat: add opt-in Mailpit service for local email testing

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -89,4 +89,15 @@ Rails.application.configure do
   config.action_dispatch.default_headers = {
     'X-Frame-Options' => 'SAMEORIGIN'
   }
+
+  # Opt-in local email testing: when MAILPIT_ENABLED=true, route all mail to the
+  # Mailpit container (see docker-compose.yml). View the inbox at
+  # http://localhost:8025. This works with deliver_later because Sidekiq delivers
+  # over SMTP to the mailpit host. Leaving it unset preserves the delivery
+  # settings configured above.
+  if ENV['MAILPIT_ENABLED'] == 'true'
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = { address: ENV.fetch('MAILPIT_HOST', 'mailpit'), port: 1025 }
+    config.action_mailer.perform_deliveries = true
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -97,7 +97,7 @@ Rails.application.configure do
   # settings configured above.
   if ENV['MAILPIT_ENABLED'] == 'true'
     config.action_mailer.delivery_method = :smtp
-    config.action_mailer.smtp_settings = { address: ENV.fetch('MAILPIT_HOST', 'mailpit'), port: 1025 }
+    config.action_mailer.smtp_settings = { address: ENV['MAILPIT_HOST'].presence || 'mailpit', port: 1025 }
     config.action_mailer.perform_deliveries = true
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     ports:
       - '8984:8983'
   # Local email testing: fake SMTP server + web inbox at http://localhost:8025.
-  # Enable delivery to it by setting MAILPIT_ENABLED=true (see env.sample).
+  # Set MAILPIT_ENABLED=true to route development mail to it (see env.sample).
   mailpit:
     container_name: ${PREFIX}-mailpit
     image: axllent/mailpit:v1.30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,15 @@ services:
       - /opt/solr/server/solr/configsets/development
     ports:
       - '8984:8983'
+  # Local email testing: fake SMTP server + web inbox at http://localhost:8025.
+  # Enable delivery to it by setting MAILPIT_ENABLED=true (see env.sample).
+  mailpit:
+    container_name: ${PREFIX}-mailpit
+    image: axllent/mailpit:v1.30
+    restart: unless-stopped
+    ports:
+      - '8025:8025'
+      - '1025:1025'
   redis:
     container_name: ${PREFIX}-redis
     image: redis:6

--- a/env.sample
+++ b/env.sample
@@ -34,3 +34,10 @@ DEPLOYMENT_ENV=dev
 # Get these values from your Matomo instance
 MATOMO_URL=https://your-matomo-instance.com/
 MATOMO_SITE_ID=1
+
+# Local email testing (Mailpit)
+# Set MAILPIT_ENABLED=true to route all development mail to the Mailpit container
+# and view it at http://localhost:8025. MAILPIT_HOST defaults to the docker
+# service name 'mailpit'; set it to 'localhost' for a native (non-docker) setup.
+MAILPIT_ENABLED=false
+MAILPIT_HOST=mailpit


### PR DESCRIPTION
**Summary of changes**

- Adds a [Mailpit](https://mailpit.axllent.org/) container to `docker-compose.yml` (image pinned to `axllent/mailpit:v1.30`) — a fake SMTP server with a web inbox at http://localhost:8025 for inspecting outgoing email during local development.
- Adds an **opt-in** delivery override in `config/environments/development.rb`: when `MAILPIT_ENABLED=true`, ActionMailer is routed to the Mailpit container over SMTP. When the flag is unset, the existing `TeSS::Config.mailer['delivery_method']` behaviour is preserved, so native/non-docker setups and custom delivery settings are unaffected.
- Documents `MAILPIT_ENABLED` and `MAILPIT_HOST` in `env.sample` (`MAILPIT_HOST` defaults to the docker service name `mailpit`; set to `localhost` for a native setup).

**Motivation and context**

Developers had no easy way to view emails sent by the app (course-interest notifications, Devise mails, etc.) in local development. Mailpit captures all outgoing mail into a browsable inbox without touching real SMTP. Delivery is gated behind an env var so the change is zero-impact unless a developer explicitly enables it. Works with `deliver_later` because Sidekiq delivers over SMTP to the Mailpit host.

**Screenshots**

Verified locally end-to-end: with `MAILPIT_ENABLED=true`, a test email sent via ActionMailer was delivered and appeared in the Mailpit inbox at http://localhost:8025.

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree to license it to the TeSS codebase under the [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional local email testing using Mailpit.
  * Added a Mailpit service to the local stack, including both the web UI and SMTP endpoint.
  * When enabled via environment settings, outgoing mail is routed to the local Mailpit instance.

* **Documentation**
  * Updated the environment template with Mailpit setup notes and default values for enabling it and selecting its host.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->