### PR TITLE
Feature/465 email rate limit subscribe unsubscribe

### DIFF
--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class CacheService
+  DEFAULT_EXPIRY = 1.hour
+
+  def self.read(key)
+    Rails.cache.read(namespaced(key))
+  end
+
+  def self.write(key, value, expires_in: DEFAULT_EXPIRY)
+    Rails.cache.write(namespaced(key), value, expires_in: expires_in)
+  end
+
+  def self.fetch(key, expires_in: DEFAULT_EXPIRY, &block)
+    Rails.cache.fetch(namespaced(key), expires_in: expires_in, &block)
+  end
+
+  def self.delete(key)
+    Rails.cache.delete(namespaced(key))
+  end
+
+  def self.exist?(key)
+    Rails.cache.exist?(namespaced(key))
+  end
+
+  def self.claim_once(key, expires_in: DEFAULT_EXPIRY)
+    Rails.cache.write(namespaced(key), true, expires_in: expires_in, unless_exist: true)
+  end
+
+  def self.namespaced(key)
+    "cache_service:#{key}"
+  end
+  private_class_method :namespaced
+end

--- a/app/services/cache_service.rb
+++ b/app/services/cache_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CacheService
-  DEFAULT_EXPIRY = 1.hour
+  DEFAULT_EXPIRY = 2.hour
 
   def self.read(key)
     Rails.cache.read(namespaced(key))

--- a/app/services/course_interest_service.rb
+++ b/app/services/course_interest_service.rb
@@ -3,7 +3,9 @@
 class CourseInterestService
   extend LogRedactor
 
+  EMAIL_RATE_LIMIT_DURATION = 1.minute
   COURSE_INTEREST_TOKEN_EXPIRY = 7.days
+
   GENERIC_SUBSCRIBE_MESSAGE = "If that email isn't already subscribed, we've sent a confirmation link."
 
   def self.subscribe_user!(course:, user:)
@@ -67,8 +69,8 @@ class CourseInterestService
   def self.request_subscription!(course:, email:)
     key = rate_limit_key(course: course, email: email, action_type: CourseInterest::ACTION_REQUEST_SUBSCRIBE)
 
-    unless CacheService.claim_once(key)
-      return { status: :error, message: "Please wait a moment before trying again.", result: :rate_limited }
+    unless CacheService.claim_once(key, expires_in: EMAIL_RATE_LIMIT_DURATION)
+      return { status: :error, message: "Please wait a minute before requesting another verification email.", result: :rate_limited }
     end
 
 
@@ -109,8 +111,8 @@ class CourseInterestService
   def self.request_unsubscription!(course:, email:)
     key = rate_limit_key(course: course, email: email, action_type: CourseInterest::ACTION_REQUEST_UNSUBSCRIBE)
 
-    unless CacheService.claim_once(key, expires_in: RATE_LIMIT_WINDOW)
-      return { status: :error, message: "Please wait a moment before trying again.", result: :rate_limited }
+    unless CacheService.claim_once(key, expires_in: EMAIL_RATE_LIMIT_DURATION)
+      return { status: :error, message: "Please wait a minute before requesting another verification email.", result: :rate_limited }
     end
 
     result, interest = CourseInterest.request_unsubscribe!(

--- a/app/services/course_interest_service.rb
+++ b/app/services/course_interest_service.rb
@@ -65,6 +65,13 @@ class CourseInterestService
   end
 
   def self.request_subscription!(course:, email:)
+    key = rate_limit_key(course: course, email: email, action_type: CourseInterest::ACTION_REQUEST_SUBSCRIBE)
+
+    unless CacheService.claim_once(key)
+      return { status: :error, message: "Please wait a moment before trying again.", result: :rate_limited }
+    end
+
+
     result, interest = CourseInterest.request_subscribe!(
       course: course,
       email: email
@@ -100,6 +107,12 @@ class CourseInterestService
   end
 
   def self.request_unsubscription!(course:, email:)
+    key = rate_limit_key(course: course, email: email, action_type: CourseInterest::ACTION_REQUEST_UNSUBSCRIBE)
+
+    unless CacheService.claim_once(key, expires_in: RATE_LIMIT_WINDOW)
+      return { status: :error, message: "Please wait a moment before trying again.", result: :rate_limited }
+    end
+
     result, interest = CourseInterest.request_unsubscribe!(
       course: course,
       email: email
@@ -192,4 +205,11 @@ class CourseInterestService
       expires_in: COURSE_INTEREST_TOKEN_EXPIRY
     )
   end
+
+  private_class_method def self.rate_limit_key(course:, email:, action_type:)
+    normalized = email.to_s.strip.downcase
+    "course_interest_rl:#{action_type}:#{course.id}:#{Digest::SHA256.hexdigest(normalized)}"
+  end
+
+
 end

--- a/app/views/courses/partials/_course_subscription_form.html.erb
+++ b/app/views/courses/partials/_course_subscription_form.html.erb
@@ -8,6 +8,7 @@
     <%= f.email_field :email,
                       class: "form-control",
                       placeholder: "Email address",
+                      value: "uniq@email.com",
                       required: true %>
 
     <%= check_box_tag :action_type,

--- a/app/views/courses/partials/_course_subscription_form.html.erb
+++ b/app/views/courses/partials/_course_subscription_form.html.erb
@@ -8,7 +8,6 @@
     <%= f.email_field :email,
                       class: "form-control",
                       placeholder: "Email address",
-                      value: "uniq@email.com",
                       required: true %>
 
     <%= check_box_tag :action_type,


### PR DESCRIPTION
Ticket: [465](https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/465 )

As per discussion, We're pausing work on this task for now.

There's an issue in Rails 7.0 caused by a known limitation in the current version of Rails — specifically in how it handles temporary cached data that's meant to "expire after some time." The current version doesn't properly clear out old entries once they expire, which is causing this bug.

This is already fixed in a newer version of Rails. Rather than build a workaround for the old version, we'll resume this task once the Rails upgrade is completed, since that will resolve the underlying issue directly.
