### PR TITLE
recaptcha-interested-user

### DIFF
--- a/app/controllers/course_subscriptions_controller.rb
+++ b/app/controllers/course_subscriptions_controller.rb
@@ -10,20 +10,17 @@ class CourseSubscriptionsController < ApplicationController
                          alert: "Logged-in users should manage subscriptions through their account."
     end
 
+    recaptcha_valid = verify_recaptcha(action: "course_interest", minimum_score: 0.5)
+    unless recaptcha_valid
+      return redirect_to course_path(course)
+    end
+
     result =
       case params[:action_type]
       when CourseInterest::ACTION_REQUEST_SUBSCRIBE
-        CourseInterestService.request_subscription!(
-          course: course,
-          email: params[:email]
-        )
-
+        CourseInterestService.request_subscription!(course: course, email: params[:email])
       when CourseInterest::ACTION_REQUEST_UNSUBSCRIBE
-        CourseInterestService.request_unsubscription!(
-          course: course,
-          email: params[:email]
-        )
-
+        CourseInterestService.request_unsubscription!(course: course, email: params[:email])
       else
         return redirect_to course_path(course), alert: "Invalid action"
       end

--- a/app/controllers/course_subscriptions_controller.rb
+++ b/app/controllers/course_subscriptions_controller.rb
@@ -15,6 +15,10 @@ class CourseSubscriptionsController < ApplicationController
       return redirect_to course_path(course)
     end
 
+    pp("in request_email_action")
+    pp("params[:action_type]")
+    pp(params[:action_type])
+
     result =
       case params[:action_type]
       when CourseInterest::ACTION_REQUEST_SUBSCRIBE
@@ -24,6 +28,9 @@ class CourseSubscriptionsController < ApplicationController
       else
         return redirect_to course_path(course), alert: "Invalid action"
       end
+
+    pp('result this this as a')
+    pp(result)
 
     if result[:status] == :error
       redirect_to course_path(course), alert: result[:message]

--- a/app/controllers/course_subscriptions_controller.rb
+++ b/app/controllers/course_subscriptions_controller.rb
@@ -15,10 +15,6 @@ class CourseSubscriptionsController < ApplicationController
       return redirect_to course_path(course)
     end
 
-    pp("in request_email_action")
-    pp("params[:action_type]")
-    pp(params[:action_type])
-
     result =
       case params[:action_type]
       when CourseInterest::ACTION_REQUEST_SUBSCRIBE
@@ -28,9 +24,6 @@ class CourseSubscriptionsController < ApplicationController
       else
         return redirect_to course_path(course), alert: "Invalid action"
       end
-
-    pp('result this this as a')
-    pp(result)
 
     if result[:status] == :error
       redirect_to course_path(course), alert: result[:message]

--- a/app/controllers/tess_devise/registrations_controller.rb
+++ b/app/controllers/tess_devise/registrations_controller.rb
@@ -25,8 +25,15 @@ class TessDevise::RegistrationsController < Devise::RegistrationsController
 
   # Pinched from https://github.com/plataformatec/devise/wiki/How-To:-Use-Recaptcha-with-Devise
   def check_captcha
-    if !Rails.application.secrets.recaptcha[:sitekey].blank? && !verify_recaptcha
+    return if Rails.application.secrets.recaptcha[:sitekey].blank?
+
+    recaptcha_valid = verify_recaptcha(action: 'signup', minimum_score: 0.5)
+    pp("recaptcha_reply ----=-=-=-=-")
+    pp(recaptcha_reply)
+
+    unless recaptcha_valid
       self.resource = resource_class.new sign_up_params
+      resource.errors.add(:base, "reCAPTCHA verification failed. Please try again.")
       respond_with_navigational(resource) { render :new }
     end
   end

--- a/app/controllers/tess_devise/registrations_controller.rb
+++ b/app/controllers/tess_devise/registrations_controller.rb
@@ -26,7 +26,7 @@ class TessDevise::RegistrationsController < Devise::RegistrationsController
   # Pinched from https://github.com/plataformatec/devise/wiki/How-To:-Use-Recaptcha-with-Devise
   def check_captcha
     return if Rails.application.secrets.recaptcha[:sitekey].blank?
-    recaptcha_valid = verify_recaptcha(action: 'signup', minimum_score: 0.5)
+    recaptcha_valid = verify_recaptcha(response: params[:recaptcha_token], action: 'signup', minimum_score: 0.5)
     unless recaptcha_valid
       self.resource = resource_class.new sign_up_params
       respond_with_navigational(resource) { render :new }

--- a/app/controllers/tess_devise/registrations_controller.rb
+++ b/app/controllers/tess_devise/registrations_controller.rb
@@ -26,14 +26,9 @@ class TessDevise::RegistrationsController < Devise::RegistrationsController
   # Pinched from https://github.com/plataformatec/devise/wiki/How-To:-Use-Recaptcha-with-Devise
   def check_captcha
     return if Rails.application.secrets.recaptcha[:sitekey].blank?
-
     recaptcha_valid = verify_recaptcha(action: 'signup', minimum_score: 0.5)
-    pp("recaptcha_reply ----=-=-=-=-")
-    pp(recaptcha_reply)
-
     unless recaptcha_valid
       self.resource = resource_class.new sign_up_params
-      resource.errors.add(:base, "reCAPTCHA verification failed. Please try again.")
       respond_with_navigational(resource) { render :new }
     end
   end

--- a/app/views/courses/partials/_course_subscription_form.html.erb
+++ b/app/views/courses/partials/_course_subscription_form.html.erb
@@ -1,101 +1,85 @@
-<div class="account-form">
-  <div class="page-header">
-    <%= page_title 'Registration' %>
+<%= form_with url: request_email_action_course_subscription_path(course),
+              method: :post,
+              local: true,
+              id: "subscription-form" do |f| %>
+
+  <!-- Email + button -->
+  <div class="input-group">
+    <%= f.email_field :email,
+                      class: "form-control",
+                      placeholder: "Email address",
+                      required: true %>
+
+    <%= check_box_tag :action_type,
+                      CourseInterest::ACTION_REQUEST_SUBSCRIBE,
+                      true,
+                      id: "course-interest-action-type",
+                      hidden: true %>
+
+
+    <span class="input-group-btn">
+      <button type="submit"
+              class="btn btn-primary"
+              id="course-interest-submit-button">
+        Subscribe
+      </button>
+    </span>
   </div>
-  <% if !TeSS::Config.feature['registration'] %>
-    <div class="panel panel-danger">
-      <div class="panel-heading">
-        <h3 class="panel-title">Registration is currently disabled</h3>
-      </div>
-      <div class="panel-body">
-        <p>Please email <%= mail_to(TeSS::Config.contact_email, TeSS::Config.contact_email) %> to request an
-          account.</p>
-        <p>In your email please include the following information:</p>
-        <ul>
-          <li>Full name</li>
-          <li>Email address</li>
-          <li>Institution/Organisation</li>
-          <li>Brief description of why you would like an account and/or the type of materials/events you would like to
-            add
-          </li>
-        </ul>
-        <p>Sorry for any inconvenience caused,</p>
-        <p>The <%= TeSS::Config.site['title_short'] %> Team</p>
-      </div>
-    </div>
-  <% else %>
-    <div class="form-middle">
-      <%# Added the HTML id: 'registration-form' to target it with JavaScript %>
-      <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { id: 'registration-form' }) do |f| %>
-        <%= account_error_messages! %>
 
-        <%= f.input :username, autofocus: true %>
+  <%= hidden_field_tag "g-recaptcha-response", nil, id: "course-interest-recaptcha-token" %>
 
-        <%= f.input :email, required: true %>
+  <!-- Checkbox underneath -->
+  <div class="course-interest-toggle">
+    <label for="course-interest-toggle" class="checkbox-label">
+      <input type="checkbox"
+             id="course-interest-toggle"
+             checked>
+      Email me when new training events for this course are published
+    </label>
+  </div>
 
-        <%= f.input :publicize_email, as: :boolean, label: 'Make my email publicly visible' %>
+<% end %>
 
-        <%= f.input :password, required: true, input_html: { autocomplete: 'off' },
-                    hint: "(#{@minimum_password_length} characters minimum)" if @minimum_password_length %>
+<script src="https://www.google.com/recaptcha/api.js?render=<%= Recaptcha.configuration.site_key %>"></script>
 
-        <%= f.input :password_confirmation, required: true, input_html: { autocomplete: 'off' } %>
+<script>
+    document.addEventListener("turbolinks:load", function () {
+        const toggle = document.getElementById("course-interest-toggle");
+        const actionType = document.getElementById("course-interest-action-type");
+        const button = document.getElementById("course-interest-submit-button");
+        const form = document.getElementById("subscription-form");
+        const tokenField = document.getElementById("course-interest-recaptcha-token");
+        if (!toggle || !actionType || !button || !form || !tokenField) return;
 
-        <% unless Rails.application.secrets.recaptcha[:sitekey].blank? -%>
-          <div class="form-group">
-            <%# Replaced standard helper with a custom hidden field for the token %>
-            <%= hidden_field_tag :recaptcha_token, '', id: 'registration-recaptcha-token' %>
-          </div>
-        <% end -%>
+        function updateUI() {
+            actionType.checked = true;
+            actionType.value = toggle.checked
+                ? "<%= CourseInterest::ACTION_REQUEST_SUBSCRIBE %>"
+                : "<%= CourseInterest::ACTION_REQUEST_UNSUBSCRIBE %>";
+            button.textContent = toggle.checked ? "Subscribe" : "Unsubscribe";
+        }
 
-        <%= f.input :processing_consent, as: :boolean, input_html: { autocomplete: 'off' },
-                    label: "I have read and understood the&nbsp;#{link_to('privacy policy', privacy_path, target: '_blank')} and consent to #{TeSS::Config.site['title_short']} processing my data.".html_safe %>
-        <div class="actions">
-          <%# Added HTML id: 'registration-submit-button' to handle disabling on click %>
-          <%= f.submit "Register", :class => 'btn btn-primary', id: 'registration-submit-button' %>
-        </div>
-      <% end %>
+        updateUI();
+        toggle.addEventListener("change", updateUI);
 
-      <div class="separator"><span>or</span></div>
+        form.addEventListener("submit", function (event) {
+            event.preventDefault();
+            button.disabled = true;
+            toggle.disabled = true;
 
-      <div class="actions">
-        <% if resource_class.omniauth_providers.any? && devise_mapping.omniauthable? %>
-          <%= render partial: 'devise/sessions/omniauth_options' %>
-        <% end %>
-      </div>
-
-      <%= render "devise/shared/links" %>
-    </div>
-  <% end %>
-</div>
-
-<% unless Rails.application.secrets.recaptcha[:sitekey].blank? -%>
-  <script src="https://www.google.com/recaptcha/api.js?render=<%= Recaptcha.configuration.site_key %>"></script>
-
-  <script>
-      document.addEventListener("turbolinks:load", function () {
-          const form = document.getElementById("registration-form");
-          const button = document.getElementById("registration-submit-button");
-          const tokenField = document.getElementById("registration-recaptcha-token");
-
-          if (!form || !button || !tokenField) return;
-
-          form.addEventListener("submit", function (event) {
-              event.preventDefault();
-              button.disabled = true;
-
-              grecaptcha.ready(function () {
-                  grecaptcha.execute("<%= Recaptcha.configuration.site_key %>", {action: "signup"})
-                      .then(function (token) {
-                          tokenField.value = token;
-                          form.submit();
-                      })
-                      .catch(function () {
-                          alert("Could not verify the form. Please try again.")
-                      }).finally(function () {
-                      button.disabled = false;
-                  });
-              });
-          });
-      });
-  </script>
-<% end -%>
+            grecaptcha.ready(function () {
+                grecaptcha.execute("<%= Recaptcha.configuration.site_key %>", {action: "course_interest"})
+                    .then(function (token) {
+                        tokenField.value = token;
+                        form.submit();
+                    })
+                    .catch(function () {
+                        alert("Could not verify the form. Please try again.")
+                    }).finally(function () {
+                    button.disabled = false;
+                    toggle.disabled = false;
+                });
+            });
+        });
+    });
+</script>

--- a/app/views/courses/partials/_course_subscription_form.html.erb
+++ b/app/views/courses/partials/_course_subscription_form.html.erb
@@ -1,82 +1,101 @@
-<%= form_with url: request_email_action_course_subscription_path(course),
-              method: :post,
-              local: true,
-              id: "subscription-form" do |f| %>
-
-  <!-- Email + button -->
-  <div class="input-group">
-    <%= f.email_field :email,
-                      class: "form-control",
-                      placeholder: "Email address",
-                      required: true %>
-
-    <%= check_box_tag :action_type,
-                      CourseInterest::ACTION_REQUEST_SUBSCRIBE,
-                      true,
-                      id: "course-interest-action-type",
-                      hidden: true %>
-
-
-    <span class="input-group-btn">
-      <button type="submit"
-              class="btn btn-primary"
-              id="course-interest-submit-button">
-        Subscribe
-      </button>
-    </span>
+<div class="account-form">
+  <div class="page-header">
+    <%= page_title 'Registration' %>
   </div>
+  <% if !TeSS::Config.feature['registration'] %>
+    <div class="panel panel-danger">
+      <div class="panel-heading">
+        <h3 class="panel-title">Registration is currently disabled</h3>
+      </div>
+      <div class="panel-body">
+        <p>Please email <%= mail_to(TeSS::Config.contact_email, TeSS::Config.contact_email) %> to request an
+          account.</p>
+        <p>In your email please include the following information:</p>
+        <ul>
+          <li>Full name</li>
+          <li>Email address</li>
+          <li>Institution/Organisation</li>
+          <li>Brief description of why you would like an account and/or the type of materials/events you would like to
+            add
+          </li>
+        </ul>
+        <p>Sorry for any inconvenience caused,</p>
+        <p>The <%= TeSS::Config.site['title_short'] %> Team</p>
+      </div>
+    </div>
+  <% else %>
+    <div class="form-middle">
+      <%# Added the HTML id: 'registration-form' to target it with JavaScript %>
+      <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { id: 'registration-form' }) do |f| %>
+        <%= account_error_messages! %>
 
-  <%= hidden_field_tag "g-recaptcha-response", nil, id: "course-interest-recaptcha-token" %>
+        <%= f.input :username, autofocus: true %>
 
-  <!-- Checkbox underneath -->
-  <div class="course-interest-toggle">
-    <label for="course-interest-toggle" class="checkbox-label">
-      <input type="checkbox"
-             id="course-interest-toggle"
-             checked>
-      Email me when new training events for this course are published
-    </label>
-  </div>
+        <%= f.input :email, required: true %>
 
-<% end %>
+        <%= f.input :publicize_email, as: :boolean, label: 'Make my email publicly visible' %>
 
-<script src="https://www.google.com/recaptcha/api.js?render=<%= Recaptcha.configuration.site_key %>"></script>
+        <%= f.input :password, required: true, input_html: { autocomplete: 'off' },
+                    hint: "(#{@minimum_password_length} characters minimum)" if @minimum_password_length %>
 
-<script>
-    document.addEventListener("turbolinks:load", function () {
-        const toggle = document.getElementById("course-interest-toggle");
-        const actionType = document.getElementById("course-interest-action-type");
-        const button = document.getElementById("course-interest-submit-button");
-        const form = document.getElementById("subscription-form");
-        const tokenField = document.getElementById("course-interest-recaptcha-token");
-        if (!toggle || !actionType || !button || !form || !tokenField) return;
+        <%= f.input :password_confirmation, required: true, input_html: { autocomplete: 'off' } %>
 
-        function updateUI() {
-            actionType.checked = true;
-            actionType.value = toggle.checked
-                ? "<%= CourseInterest::ACTION_REQUEST_SUBSCRIBE %>"
-                : "<%= CourseInterest::ACTION_REQUEST_UNSUBSCRIBE %>";
-            button.textContent = toggle.checked ? "Subscribe" : "Unsubscribe";
-        }
+        <% unless Rails.application.secrets.recaptcha[:sitekey].blank? -%>
+          <div class="form-group">
+            <%# Replaced standard helper with a custom hidden field for the token %>
+            <%= hidden_field_tag :recaptcha_token, '', id: 'registration-recaptcha-token' %>
+          </div>
+        <% end -%>
 
-        updateUI();
-        toggle.addEventListener("change", updateUI);
+        <%= f.input :processing_consent, as: :boolean, input_html: { autocomplete: 'off' },
+                    label: "I have read and understood the&nbsp;#{link_to('privacy policy', privacy_path, target: '_blank')} and consent to #{TeSS::Config.site['title_short']} processing my data.".html_safe %>
+        <div class="actions">
+          <%# Added HTML id: 'registration-submit-button' to handle disabling on click %>
+          <%= f.submit "Register", :class => 'btn btn-primary', id: 'registration-submit-button' %>
+        </div>
+      <% end %>
 
-        form.addEventListener("submit", function (event) {
-            event.preventDefault();
-            button.disabled = true;
+      <div class="separator"><span>or</span></div>
 
-            grecaptcha.ready(function () {
-                grecaptcha.execute("<%= Recaptcha.configuration.site_key %>", { action: "course_interest" })
-                    .then(function (token) {
-                        tokenField.value = token;
-                        form.submit();
-                    })
-                    .catch(function () {
-                        button.disabled = false;
-                        alert("Could not verify the form. Please try again.")
-                    });
-            });
-        });
-    });
-</script>
+      <div class="actions">
+        <% if resource_class.omniauth_providers.any? && devise_mapping.omniauthable? %>
+          <%= render partial: 'devise/sessions/omniauth_options' %>
+        <% end %>
+      </div>
+
+      <%= render "devise/shared/links" %>
+    </div>
+  <% end %>
+</div>
+
+<% unless Rails.application.secrets.recaptcha[:sitekey].blank? -%>
+  <script src="https://www.google.com/recaptcha/api.js?render=<%= Recaptcha.configuration.site_key %>"></script>
+
+  <script>
+      document.addEventListener("turbolinks:load", function () {
+          const form = document.getElementById("registration-form");
+          const button = document.getElementById("registration-submit-button");
+          const tokenField = document.getElementById("registration-recaptcha-token");
+
+          if (!form || !button || !tokenField) return;
+
+          form.addEventListener("submit", function (event) {
+              event.preventDefault();
+              button.disabled = true;
+
+              grecaptcha.ready(function () {
+                  grecaptcha.execute("<%= Recaptcha.configuration.site_key %>", {action: "signup"})
+                      .then(function (token) {
+                          tokenField.value = token;
+                          form.submit();
+                      })
+                      .catch(function () {
+                          alert("Could not verify the form. Please try again.")
+                      }).finally(function () {
+                      button.disabled = false;
+                  });
+              });
+          });
+      });
+  </script>
+<% end -%>

--- a/app/views/courses/partials/_course_subscription_form.html.erb
+++ b/app/views/courses/partials/_course_subscription_form.html.erb
@@ -16,6 +16,7 @@
                       id: "course-interest-action-type",
                       hidden: true %>
 
+
     <span class="input-group-btn">
       <button type="submit"
               class="btn btn-primary"
@@ -24,6 +25,8 @@
       </button>
     </span>
   </div>
+
+  <%= hidden_field_tag "g-recaptcha-response", nil, id: "course-interest-recaptcha-token" %>
 
   <!-- Checkbox underneath -->
   <div class="course-interest-toggle">
@@ -37,12 +40,16 @@
 
 <% end %>
 
+<script src="https://www.google.com/recaptcha/api.js?render=<%= Recaptcha.configuration.site_key %>"></script>
+
 <script>
     document.addEventListener("turbolinks:load", function () {
         const toggle = document.getElementById("course-interest-toggle");
         const actionType = document.getElementById("course-interest-action-type");
         const button = document.getElementById("course-interest-submit-button");
-        if (!toggle || !actionType || !button) return;
+        const form = document.getElementById("subscription-form");
+        const tokenField = document.getElementById("course-interest-recaptcha-token");
+        if (!toggle || !actionType || !button || !form || !tokenField) return;
 
         function updateUI() {
             actionType.checked = true;
@@ -54,5 +61,22 @@
 
         updateUI();
         toggle.addEventListener("change", updateUI);
+
+        form.addEventListener("submit", function (event) {
+            event.preventDefault();
+            button.disabled = true;
+
+            grecaptcha.ready(function () {
+                grecaptcha.execute("<%= Recaptcha.configuration.site_key %>", { action: "course_interest" })
+                    .then(function (token) {
+                        tokenField.value = token;
+                        form.submit();
+                    })
+                    .catch(function () {
+                        button.disabled = false;
+                        alert("Could not verify the form. Please try again.")
+                    });
+            });
+        });
     });
 </script>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -38,7 +38,7 @@
 
         <% unless Rails.application.secrets.recaptcha[:sitekey].blank? -%>
           <div class="form-group">
-            <%= recaptcha_tags ajax: true %>
+            <%= recaptcha_v3(action: 'signup', ajax: true) %>
           </div>
         <% end -%>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -77,18 +77,27 @@
               event.preventDefault();
               button.disabled = true;
 
-              grecaptcha.ready(function () {
-                  grecaptcha.execute("<%= Recaptcha.configuration.site_key %>", {action: "signup"})
-                      .then(function (token) {
-                          tokenField.value = token;
-                          form.submit();
-                      })
-                      .catch(function () {
-                          alert("Could not verify the form. Please try again.")
-                      }).finally(function () {
-                      button.disabled = false;
-                  });
-              });
+              try {
+                  if (typeof grecaptcha !== 'undefined' && grecaptcha.ready) {
+                      grecaptcha.ready(function () {
+                          grecaptcha.execute("<%= Recaptcha.configuration.site_key %>", {action: "signup"})
+                              .then(function (token) {
+                                  tokenField.value = token;
+                                  form.submit();
+                              })
+                              .catch(function (error) {
+                                  alert("Could not verify the form. Please check your connection and try again.");
+                              }).finally(function () {
+                              button.disabled = false;
+                          });
+                      });
+                  } else {
+                      throw new Error("grecaptcha API not loaded.");
+                  }
+              } catch (e) {
+                  alert("Verification service unavailable. Please try submitting without captcha.");
+                  button.disabled = false;
+              }
           });
       });
   </script>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -22,7 +22,7 @@
     </div>
   <% else %>
     <div class="form-middle">
-      <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { id: 'registration-form' }) do |f| %>
         <%= account_error_messages! %>
 
         <%= f.input :username, autofocus: true %>
@@ -38,14 +38,14 @@
 
         <% unless Rails.application.secrets.recaptcha[:sitekey].blank? -%>
           <div class="form-group">
-            <%= recaptcha_v3(action: 'signup', ajax: true) %>
+            <%= hidden_field_tag :recaptcha_token, '', id: 'registration-recaptcha-token' %>
           </div>
         <% end -%>
 
         <%= f.input :processing_consent, as: :boolean, input_html: { autocomplete: 'off' },
                     label: "I have read and understood the&nbsp;#{link_to('privacy policy', privacy_path, target: '_blank')} and consent to #{TeSS::Config.site['title_short']} processing my data.".html_safe %>
         <div class="actions">
-          <%= f.submit "Register", :class => 'btn btn-primary' %>
+          <%= f.submit "Register", :class => 'btn btn-primary', id: 'registration-submit-button' %>
         </div>
       <% end %>
 
@@ -61,3 +61,35 @@
     </div>
   <% end %>
 </div>
+
+<% unless Rails.application.secrets.recaptcha[:sitekey].blank? -%>
+  <script src="https://www.google.com/recaptcha/api.js?render=<%= Recaptcha.configuration.site_key %>"></script>
+
+  <script>
+      document.addEventListener("turbolinks:load", function () {
+          const form = document.getElementById("registration-form");
+          const button = document.getElementById("registration-submit-button");
+          const tokenField = document.getElementById("registration-recaptcha-token");
+
+          if (!form || !button || !tokenField) return;
+
+          form.addEventListener("submit", function (event) {
+              event.preventDefault();
+              button.disabled = true;
+
+              grecaptcha.ready(function () {
+                  grecaptcha.execute("<%= Recaptcha.configuration.site_key %>", {action: "signup"})
+                      .then(function (token) {
+                          tokenField.value = token;
+                          form.submit();
+                      })
+                      .catch(function () {
+                          alert("Could not verify the form. Please try again.")
+                      }).finally(function () {
+                      button.disabled = false;
+                  });
+              });
+          });
+      });
+  </script>
+<% end -%>


### PR DESCRIPTION
ticket: [fix recaptcha for the interested user feature so that the bots are not able to mess around with the emails.#477](https://app.zenhub.com/workspaces/th-developmentdesigning-board-6565ea6f792dae0625b5c739/issues/gh/scilifelab-traininghub-platform/tess/477) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added reCAPTCHA verification to course interest submissions and account registration.
  * Invalid course interest verification redirects back to the course page.
  * Registration verification failures preserve the existing form and error flow.
  * reCAPTCHA is skipped when no site key is configured.
* **User Experience**
  * Course subscription forms now support account registration, consent, and optional OAuth sign-in.
  * Submission buttons are protected against duplicate requests, with alerts when verification fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->