### PR TITLE
fix(admin): render user forms with Devise 5 password length validators

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -13,8 +13,10 @@ RailsAdmin::Config::Fields::Base.register_instance_option :valid_length do
     field_name = name
     validator = model.validators_on(field_name).detect { |v| v.kind == :length }
 
+    limits = %i[minimum maximum is]
+
     (validator&.options || {}).to_h do |key, option|
-      next [key, option] unless option.respond_to?(:call)
+      next [key, option] unless limits.include?(key) && option.respond_to?(:call)
 
       value = begin
         option.call(model)

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,3 +1,29 @@
+# Devise 5 declares the password length rule with procs, e.g.
+#   validates_length_of :password, minimum: proc { password_length.min }
+# RailsAdmin writes each field's help text by comparing those options against
+# integers, so every user form under /admin fails to render with
+# "comparison of Integer with Proc failed". Here we run the procs first and hand
+# RailsAdmin the numbers they return.
+# Upstream bug, still present in rails_admin 3.3.0:
+# https://github.com/railsadminteam/rails_admin/issues/3711
+# Remove this patch once a released version carries the upstream fix.
+RailsAdmin::Config::Fields::Base.register_instance_option :valid_length do
+  @valid_length ||= begin
+    model = abstract_model.model
+    validator = model.validators_on(name).detect { |v| v.kind == :length }
+
+    (validator&.options || {}).transform_values do |option|
+      next option unless option.respond_to?(:call)
+
+      begin
+        option.call(model)
+      rescue StandardError
+        nil
+      end
+    end
+  end
+end
+
 RailsAdmin.config do |config|
   config.main_app_name = ['TeSS', 'Administration']
   config.asset_source = :sprockets

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -10,16 +10,23 @@
 RailsAdmin::Config::Fields::Base.register_instance_option :valid_length do
   @valid_length ||= begin
     model = abstract_model.model
-    validator = model.validators_on(name).detect { |v| v.kind == :length }
+    field_name = name
+    validator = model.validators_on(field_name).detect { |v| v.kind == :length }
 
-    (validator&.options || {}).transform_values do |option|
-      next option unless option.respond_to?(:call)
+    (validator&.options || {}).to_h do |key, option|
+      next [key, option] unless option.respond_to?(:call)
 
-      begin
+      value = begin
         option.call(model)
-      rescue StandardError
+      rescue StandardError => e
+        # Drop the option rather than break the form, but say so loudly: a
+        # silently missing limit is how this goes unnoticed for months.
+        Rails.logger.error("RailsAdmin could not resolve the :#{key} length option for " \
+                           "#{model}##{field_name}: #{e.class} - #{e.message}")
         nil
       end
+
+      [key, value]
     end
   end
 end

--- a/test/unit/rails_admin_user_fields_test.rb
+++ b/test/unit/rails_admin_user_fields_test.rb
@@ -26,4 +26,37 @@ class RailsAdminUserFieldsTest < ActiveSupport::TestCase
     assert_equal User.password_length.max, field.valid_length[:maximum]
     assert_equal true, field.valid_length[:allow_blank]
   end
+
+  # The patch has to keep the form alive even when an option cannot be resolved,
+  # so a failing one is dropped rather than allowed to break the page - but it
+  # has to be reported, otherwise a missing limit goes unnoticed.
+  test 'a length option that cannot be resolved is dropped and logged' do
+    field = RailsAdmin.config(User).edit.fields.detect { |f| f.name == :password }
+    validator = ActiveModel::Validations::LengthValidator.new(attributes: [:password],
+                                                              minimum: proc { raise 'cannot be resolved' },
+                                                              maximum: 72)
+    logged = []
+
+    Rails.logger.stub(:error, ->(message) { logged << message }) do
+      with_stubbed_validators(field, [validator]) do
+        assert_nil field.valid_length[:minimum]
+        assert_equal 72, field.valid_length[:maximum]
+      end
+    end
+
+    assert_match(/could not resolve the :minimum length option for User#password/, logged.join("\n"))
+    assert_match(/cannot be resolved/, logged.join("\n"))
+  end
+
+  private
+
+  # The field caches the options it resolved, so clear that cache around the
+  # stub to leave the shared RailsAdmin config untouched for the other tests.
+  def with_stubbed_validators(field, validators, &block)
+    field.instance_variable_set(:@valid_length, nil)
+    User.stub(:validators_on, validators, &block)
+  ensure
+    field.instance_variable_set(:@valid_length, nil)
+    field.instance_variable_set(:@help, nil)
+  end
 end

--- a/test/unit/rails_admin_user_fields_test.rb
+++ b/test/unit/rails_admin_user_fields_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class RailsAdminUserFieldsTest < ActiveSupport::TestCase
+  # Devise 5 declares the password length rule with procs, which made RailsAdmin
+  # raise "comparison of Integer with Proc failed" while building the help text
+  # for the field, breaking the whole user form under /admin.
+  # See the patch in config/initializers/rails_admin.rb
+  test 'password field help text renders with proc-based length validators' do
+    field = RailsAdmin.config(User).edit.fields.detect { |f| f.name == :password }
+    assert field, 'expected RailsAdmin to expose a password field on User'
+
+    help = nil
+    assert_nothing_raised { help = field.help }
+
+    assert_includes help, User.password_length.min.to_s
+    assert_includes help, User.password_length.max.to_s
+  end
+
+  test 'length options that are plain numbers are left alone' do
+    field = RailsAdmin.config(User).edit.fields.detect { |f| f.name == :username }
+
+    assert_nothing_raised { field.help }
+  end
+end

--- a/test/unit/rails_admin_user_fields_test.rb
+++ b/test/unit/rails_admin_user_fields_test.rb
@@ -16,9 +16,14 @@ class RailsAdminUserFieldsTest < ActiveSupport::TestCase
     assert_includes help, User.password_length.max.to_s
   end
 
-  test 'length options that are plain numbers are left alone' do
-    field = RailsAdmin.config(User).edit.fields.detect { |f| f.name == :username }
+  # The password rule carries both kinds of option, so one field covers both
+  # halves of the patch: procs get called, anything else is passed through.
+  test 'callable length options are resolved and plain ones are left alone' do
+    field = RailsAdmin.config(User).edit.fields.detect { |f| f.name == :password }
+    assert field, 'expected RailsAdmin to expose a password field on User'
 
-    assert_nothing_raised { field.help }
+    assert_equal User.password_length.min, field.valid_length[:minimum]
+    assert_equal User.password_length.max, field.valid_length[:maximum]
+    assert_equal true, field.valid_length[:allow_blank]
   end
 end


### PR DESCRIPTION
**Summary of changes**

- Fixes the 500 error on every user form under `/admin` (`/admin/user/<id>/edit` and `/admin/user/new`), which failed with `ActionView::Template::Error (comparison of Integer with Proc failed)`.
- Adds a small compatibility patch in `config/initializers/rails_admin.rb` that resolves callable (proc-based) length validator options before RailsAdmin compares them against integers.
- Adds a regression test in `test/unit/rails_admin_user_fields_test.rb`.

**Motivation and context**

Devise 5 (introduced in #460, the security bump 4.9.2 -> 5.0.4) changed how the password length rule is declared:

```ruby
# devise 4.9.2
validates_length_of :password, within: password_length, allow_blank: true
# devise 5.0.4
validates_length_of :password, minimum: proc { password_length.min }, maximum: proc { password_length.max }, allow_blank: true
```

RailsAdmin generates each field's help text ("Optional. Length of 8-72.") by reading the model's length validator and doing arithmetic on its options:

```ruby
# rails_admin-3.1.3/lib/rails_admin/config/fields/types/string.rb:30
min_length = [0, valid_length[:minimum] || nil].compact.max
```

With Devise 5 that option is a `Proc`, not an Integer, so Ruby raises `comparison of Integer with Proc failed`, the template fails mid-render and Rails returns a 500. The crash happens while *drawing* the form, before anything is submitted, which is why the New-user form breaks identically and why nothing is written to the database. Password validation itself is unaffected — ActiveModel calls the proc before comparing (`active_model/validations/length.rb:50`), so passwords are still enforced at 8-72 characters.

This is a known upstream bug, unfixed since January 2025: https://github.com/railsadminteam/rails_admin/issues/3711

Alternatives considered:

- **Revert the Devise bump** — rejected. There is no security-patched 4.x release (4.9.4, April 2024, is the last one), so reverting re-opens CVE-2026-32700, a `:confirmable` change-email race that applies to us since `:confirmable` is enabled on `User`, plus CVE-2026-40295. It would also only postpone the problem to the next Devise upgrade.
- **Upgrade RailsAdmin** — does not help; 3.1.4, 3.2.1 and 3.3.0 all still contain the identical broken lines.
- **Exclude the password fields from `/admin`** (the workaround suggested upstream) — works, but admins lose the ability to set a user's password.

Note: upstream `ElixirTeSS/TeSS` is on devise 5.0.4 + rails_admin 3.3.0 with no workaround in their RailsAdmin initializer, so they very likely have this bug unnoticed. Worth reporting to them and to rails_admin separately.

The patch is temporary by design and carries a comment saying so — it should be deleted once the upstream fix ships in a released gem version.

**Screenshots**

N/A (restores the standard RailsAdmin user form; the only visible difference is the help text under the password field reading "Optional. Length of 8-72.").

**Checklist**

- [x] I have read and followed the [CONTRIBUTING](https://github.com/ElixirTeSS/TeSS/blob/master/CONTRIBUTING.md) guide.
- [x] I confirm that I have the authority necessary to make this contribution on behalf of its copyright owner and agree
  to license it to the TeSS codebase under the 
  [BSD license](https://github.com/ElixirTeSS/TeSS/blob/master/LICENSE).

**Testing**

- New regression test passes with the patch and errors with `ArgumentError: comparison of Integer with Proc failed` without it (verified by stashing the patch).
- Full suite: `1426 tests, 5887 assertions, 0 failures, 0 errors, 104 skips`.
- Rubocop on the touched files introduces no new offences.
- Manual: signed in as an admin locally, `/admin/user/<id>/edit`, `/admin/user/new` and `/admin/user/2/edit` all return 200 and save correctly.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password field help text in the administration interface when password length rules are configured dynamically.
  * Preserved existing help text behavior for fixed password length settings.
  * Prevented errors from disrupting the interface when dynamic validation settings cannot be evaluated.

* **Tests**
  * Added coverage for dynamic and fixed password length validation settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->